### PR TITLE
Add fine-grained per-block diagnostics

### DIFF
--- a/src/pathsim/simulation.py
+++ b/src/pathsim/simulation.py
@@ -37,6 +37,7 @@ from .utils.analysis import Timer
 from .utils.deprecation import deprecated
 from .utils.portreference import PortReference
 from .utils.progresstracker import ProgressTracker
+from .utils.diagnostics import Diagnostics, ConvergenceTracker, StepTracker
 from .utils.logger import LoggerManager
 
 from .solvers import SSPRK22, SteadyState
@@ -165,17 +166,18 @@ class Simulation:
     """
 
     def __init__(
-        self, 
-        blocks=None, 
-        connections=None, 
+        self,
+        blocks=None,
+        connections=None,
         events=None,
-        dt=SIM_TIMESTEP, 
-        dt_min=SIM_TIMESTEP_MIN, 
-        dt_max=SIM_TIMESTEP_MAX, 
-        Solver=SSPRK22, 
-        tolerance_fpi=SIM_TOLERANCE_FPI, 
-        iterations_max=SIM_ITERATIONS_MAX, 
+        dt=SIM_TIMESTEP,
+        dt_min=SIM_TIMESTEP_MIN,
+        dt_max=SIM_TIMESTEP_MAX,
+        Solver=SSPRK22,
+        tolerance_fpi=SIM_TOLERANCE_FPI,
+        iterations_max=SIM_ITERATIONS_MAX,
         log=LOG_ENABLE,
+        diagnostics=False,
         **solver_kwargs
         ):
 
@@ -225,6 +227,17 @@ class Simulation:
 
         #flag for setting the simulation active
         self._active = True
+
+        #convergence trackers for the three solver loops
+        self._loop_tracker = ConvergenceTracker()
+        self._solve_tracker = ConvergenceTracker()
+        self._step_tracker = StepTracker()
+
+        #diagnostics snapshot (None when disabled)
+        self.diagnostics = Diagnostics() if diagnostics else None
+
+        #diagnostics history (list of snapshots per timestep)
+        self._diagnostics_history = [] if diagnostics == "history" else None
 
         #initialize logging 
         logger_mgr = LoggerManager(
@@ -815,6 +828,15 @@ class Simulation:
         for event in self.events:
             event.reset()
 
+        #reset convergence trackers and diagnostics
+        self._loop_tracker.reset()
+        self._solve_tracker.reset()
+        self._step_tracker.reset()
+        if self.diagnostics is not None:
+            self.diagnostics = Diagnostics()
+        if self._diagnostics_history is not None:
+            self._diagnostics_history.clear()
+
         #evaluate system function
         self._update(self.time)
 
@@ -1026,19 +1048,20 @@ class Simulation:
                     if connection: connection.update()
 
             #step boosters of loop closing connections
-            max_err = 0.0
+            self._loop_tracker.begin_iteration()
             for con_booster in self.boosters:
-                err = con_booster.update()
-                if err > max_err:
-                    max_err = err
-                       
+                self._loop_tracker.record(con_booster, con_booster.update())
+
             #check convergence
-            if max_err <= self.tolerance_fpi:
+            if self._loop_tracker.converged(self.tolerance_fpi):
+                self._loop_tracker.iterations = iteration
                 return
 
-        #not converged -> error
-        _msg = "algebraic loop not converged (iters: {}, err: {})".format(
-            self.iterations_max, max_err
+        #not converged -> error with per-connection details
+        self._loop_tracker.iterations = self.iterations_max
+        details = self._loop_tracker.details(lambda b: str(b.connection))
+        _msg = "algebraic loop not converged (iters: {}, err: {:.2e})\n{}".format(
+            self.iterations_max, self._loop_tracker.max_error, "\n".join(details)
             )
         self.logger.error(_msg)
         raise RuntimeError(_msg)
@@ -1080,26 +1103,21 @@ class Simulation:
 
             #evaluate system equation (this is a fixed point loop)
             self._update(t)
-            total_evals += 1            
+            total_evals += 1
 
             #advance solution of implicit solver
-            max_error = 0.0
+            self._solve_tracker.begin_iteration()
             for block in self._blocks_dyn:
-
-                #skip inactive blocks
-                if not block: 
+                if not block:
                     continue
-                
-                #advance solution (internal optimizer)
-                error = block.solve(t, dt)
-                if error > max_error:
-                    max_error = error
+                self._solve_tracker.record(block, block.solve(t, dt))
 
-            #check for convergence (only error)
-            if max_error <= self.tolerance_fpi:
-                return True, total_evals, it+1
+            #check for convergence
+            if self._solve_tracker.converged(self.tolerance_fpi):
+                self._solve_tracker.iterations = it + 1
+                return True, total_evals, it + 1
 
-        #not converged in 'self.iterations_max' steps
+        self._solve_tracker.iterations = self.iterations_max
         return False, total_evals, self.iterations_max
 
 
@@ -1156,8 +1174,9 @@ class Simulation:
 
         #catch non convergence
         if not success:
-            _msg = "STEADYSTATE -> FINISHED (success: {}, evals: {}, iters: {}, runtime: {})".format(
-                success, evals, iters, T)
+            details = self._solve_tracker.details(lambda b: b.__class__.__name__)
+            _msg = "STEADYSTATE -> FAILED (evals: {}, iters: {}, runtime: {})\n{}".format(
+                evals, iters, T, "\n".join(details))
             self.logger.error(_msg)
             raise RuntimeError(_msg)
 
@@ -1276,32 +1295,14 @@ class Simulation:
             rescale factor for timestep
         """
 
-        #initial timestep rescale and error estimate
-        success, max_error_norm, min_scale = True, 0.0, None
+        self._step_tracker.reset()
 
-        #step blocks and get error estimates if available
         for block in self._blocks_dyn:
-
-            #skip inactive blocks
             if not block: continue
-
-            #step the block
             suc, err_norm, scl = block.step(t, dt)
+            self._step_tracker.record(block, suc, err_norm, scl)
 
-            #check solver stepping success
-            if not suc:
-                success = False
-
-            #update error tracking
-            if err_norm > max_error_norm:
-                max_error_norm = err_norm
-
-            #track minimum relevant scale directly (avoids list allocation)
-            if scl is not None:
-                if min_scale is None or scl < min_scale:
-                    min_scale = scl
-
-        return success, max_error_norm, min_scale if min_scale is not None else 1.0
+        return self._step_tracker.success, self._step_tracker.max_error, self._step_tracker.scale
 
 
     # timestepping ----------------------------------------------------------------
@@ -1469,10 +1470,19 @@ class Simulation:
                     total_evals += evals
                     total_solver_its += solver_its
 
-                    #adaptive implicit: revert if solver didn't converge
-                    if not success and is_adaptive:
-                        self._revert(self.time)
-                        return False, 0.0, 0.5, total_evals + 1, total_solver_its
+                    #implicit solver didn't converge
+                    if not success:
+                        details = self._solve_tracker.details(lambda b: b.__class__.__name__)
+                        if is_adaptive:
+                            self.logger.warning(
+                                "implicit solver not converged, reverting step at t={:.6f}\n{}".format(
+                                    time_stage, "\n".join(details)))
+                            self._revert(self.time)
+                            return False, 0.0, 0.5, total_evals + 1, total_solver_its
+                        else:
+                            self.logger.warning(
+                                "implicit solver not converged at t={:.6f} (iters: {})\n{}".format(
+                                    time_stage, solver_its, "\n".join(details)))
                 else:
                     #explicit: evaluate system equation
                     self._update(time_stage)
@@ -1510,6 +1520,19 @@ class Simulation:
                 event.resolve(self.time + ratio * dt)
                 self._update(time_dt)
                 total_evals += 1
+
+        #update diagnostics snapshot for this timestep
+        if self.diagnostics is not None:
+            self.diagnostics = Diagnostics(
+                time=time_dt,
+                loop_residuals=dict(self._loop_tracker.errors),
+                loop_iterations=self._loop_tracker.iterations,
+                solve_residuals=dict(self._solve_tracker.errors),
+                solve_iterations=self._solve_tracker.iterations,
+                step_errors=dict(self._step_tracker.errors),
+            )
+            if self._diagnostics_history is not None:
+                self._diagnostics_history.append(self.diagnostics)
 
         #sample data after successful timestep
         self._sample(time_dt, dt)

--- a/src/pathsim/utils/diagnostics.py
+++ b/src/pathsim/utils/diagnostics.py
@@ -1,0 +1,244 @@
+#########################################################################################
+##
+##                     CONVERGENCE TRACKING AND DIAGNOSTICS
+##                            (utils/diagnostics.py)
+##
+##         Convergence tracker classes for the simulation solver loops
+##         and optional per-timestep diagnostics snapshot.
+##
+#########################################################################################
+
+# IMPORTS ===============================================================================
+
+from dataclasses import dataclass, field
+
+
+# CONVERGENCE TRACKER ===================================================================
+
+class ConvergenceTracker:
+    """Tracks per-object scalar errors and convergence for fixed-point loops.
+
+    Used by the algebraic loop solver (keyed by ConnectionBooster) and
+    the implicit ODE solver (keyed by Block).
+
+    Attributes
+    ----------
+    errors : dict
+        object -> float, per-object error from most recent iteration
+    max_error : float
+        maximum error across all objects in current iteration
+    iterations : int
+        number of iterations taken
+    """
+
+    __slots__ = ('errors', 'max_error', 'iterations')
+
+    def __init__(self):
+        self.errors = {}
+        self.max_error = 0.0
+        self.iterations = 0
+
+
+    def reset(self):
+        """Clear all state."""
+        self.errors.clear()
+        self.max_error = 0.0
+        self.iterations = 0
+
+
+    def begin_iteration(self):
+        """Reset per-iteration state before sweeping objects."""
+        self.errors.clear()
+        self.max_error = 0.0
+
+
+    def record(self, obj, error):
+        """Record a single object's error and update the running max."""
+        self.errors[obj] = error
+        if error > self.max_error:
+            self.max_error = error
+
+
+    def converged(self, tolerance):
+        """Check if max error is within tolerance."""
+        return self.max_error <= tolerance
+
+
+    def details(self, label_fn):
+        """Format per-object error breakdown for error messages.
+
+        Parameters
+        ----------
+        label_fn : callable
+            obj -> str, produces a human-readable label
+
+        Returns
+        -------
+        list[str]
+            formatted lines like "  Integrator: 1.23e-04"
+        """
+        return [f"  {label_fn(obj)}: {err:.2e}" for obj, err in self.errors.items()]
+
+
+# STEP TRACKER ==========================================================================
+
+class StepTracker:
+    """Tracks per-block adaptive step results.
+
+    Used by the adaptive error control loop. Each block produces a tuple
+    (success, err_norm, scale) and this tracker aggregates them.
+
+    Attributes
+    ----------
+    errors : dict
+        block -> (success, err_norm, scale) from most recent step
+    success : bool
+        AND of all block successes
+    max_error : float
+        maximum error norm across all blocks
+    min_scale : float | None
+        minimum scale factor (None if no block provides one)
+    """
+
+    __slots__ = ('errors', 'success', 'max_error', 'min_scale')
+
+    def __init__(self):
+        self.errors = {}
+        self.success = True
+        self.max_error = 0.0
+        self.min_scale = None
+
+
+    def reset(self):
+        """Clear state for a new step."""
+        self.errors.clear()
+        self.success = True
+        self.max_error = 0.0
+        self.min_scale = None
+
+
+    def record(self, block, success, err_norm, scale):
+        """Record a single block's step result."""
+        self.errors[block] = (success, err_norm, scale)
+        if not success:
+            self.success = False
+        if err_norm > self.max_error:
+            self.max_error = err_norm
+        if scale is not None:
+            if self.min_scale is None or scale < self.min_scale:
+                self.min_scale = scale
+
+
+    @property
+    def scale(self):
+        """Effective scale factor (1.0 when no block provides one)."""
+        return self.min_scale if self.min_scale is not None else 1.0
+
+
+# DIAGNOSTICS SNAPSHOT ==================================================================
+
+@dataclass
+class Diagnostics:
+    """Per-timestep convergence diagnostics snapshot.
+
+    Populated by the simulation engine after each successful timestep
+    from the three convergence trackers. Provides read-only accessors
+    for the worst offending block or connection.
+
+    Attributes
+    ----------
+    time : float
+        simulation time
+    loop_residuals : dict
+        per-booster algebraic loop residuals (booster -> residual)
+    loop_iterations : int
+        number of algebraic loop iterations taken
+    solve_residuals : dict
+        per-block implicit solver residuals (block -> residual)
+    solve_iterations : int
+        number of implicit solver iterations taken
+    step_errors : dict
+        per-block adaptive step data (block -> (success, err_norm, scale))
+    """
+    time: float = 0.0
+    loop_residuals: dict = field(default_factory=dict)
+    loop_iterations: int = 0
+    solve_residuals: dict = field(default_factory=dict)
+    solve_iterations: int = 0
+    step_errors: dict = field(default_factory=dict)
+
+
+    @staticmethod
+    def _label(obj):
+        """Human-readable label for a block or booster."""
+        if hasattr(obj, 'connection'):
+            return str(obj.connection)
+        return obj.__class__.__name__
+
+
+    def worst_block(self):
+        """Block with the highest residual across solve and step errors.
+
+        Returns
+        -------
+        tuple[str, float] or None
+            (label, error) or None if no data
+        """
+        worst, worst_err = None, -1.0
+
+        for obj, err in self.solve_residuals.items():
+            if err > worst_err:
+                worst, worst_err = obj, err
+
+        for obj, (_, err_norm, _) in self.step_errors.items():
+            if err_norm > worst_err:
+                worst, worst_err = obj, err_norm
+
+        if worst is None:
+            return None
+        return self._label(worst), worst_err
+
+
+    def worst_booster(self):
+        """Connection booster with the highest algebraic loop residual.
+
+        Returns
+        -------
+        tuple[str, float] or None
+            (label, residual) or None if no data
+        """
+        if not self.loop_residuals:
+            return None
+
+        worst = max(self.loop_residuals, key=self.loop_residuals.get)
+        return self._label(worst), self.loop_residuals[worst]
+
+
+    def summary(self):
+        """Formatted summary of this diagnostics snapshot.
+
+        Returns
+        -------
+        str
+            human-readable diagnostics summary
+        """
+        lines = [f"Diagnostics at t = {self.time:.6f}"]
+
+        if self.step_errors:
+            lines.append(f"\n  Adaptive step errors:")
+            for obj, (suc, err, scl) in self.step_errors.items():
+                status = "OK" if suc else "FAIL"
+                scl_str = f"{scl:.3f}" if scl is not None else "N/A"
+                lines.append(f"    {status}  {self._label(obj)}: err={err:.2e}, scale={scl_str}")
+
+        if self.solve_residuals:
+            lines.append(f"\n  Implicit solver residuals ({self.solve_iterations} iterations):")
+            for obj, err in self.solve_residuals.items():
+                lines.append(f"    {self._label(obj)}: {err:.2e}")
+
+        if self.loop_residuals:
+            lines.append(f"\n  Algebraic loop residuals ({self.loop_iterations} iterations):")
+            for obj, err in self.loop_residuals.items():
+                lines.append(f"    {self._label(obj)}: {err:.2e}")
+
+        return "\n".join(lines)

--- a/tests/pathsim/test_diagnostics.py
+++ b/tests/pathsim/test_diagnostics.py
@@ -1,0 +1,353 @@
+"""Tests for simulation diagnostics."""
+
+import unittest
+import numpy as np
+
+from pathsim import Simulation, Connection
+from pathsim.blocks import Source, Integrator, Amplifier, Adder, Scope
+from pathsim.utils.diagnostics import Diagnostics, ConvergenceTracker, StepTracker
+
+
+class TestDiagnosticsOff(unittest.TestCase):
+    """Verify diagnostics=False (default) has no side effects."""
+
+    def test_diagnostics_none_by_default(self):
+        src = Source(lambda t: 1.0)
+        integ = Integrator()
+        sim = Simulation(
+            blocks=[src, integ],
+            connections=[Connection(src, integ)],
+            dt=0.01
+        )
+        self.assertIsNone(sim.diagnostics)
+        sim.run(0.1)
+        self.assertIsNone(sim.diagnostics)
+
+
+class TestDiagnosticsExplicitSolver(unittest.TestCase):
+    """Diagnostics with an explicit solver (step errors only)."""
+
+    def test_snapshot_after_run(self):
+        src = Source(lambda t: np.sin(t))
+        integ = Integrator()
+        sim = Simulation(
+            blocks=[src, integ],
+            connections=[Connection(src, integ)],
+            dt=0.01,
+            diagnostics=True
+        )
+        sim.run(0.1)
+
+        diag = sim.diagnostics
+        self.assertIsInstance(diag, Diagnostics)
+        self.assertAlmostEqual(diag.time, sim.time, places=6)
+
+        #explicit solver: step errors should be populated
+        self.assertGreater(len(diag.step_errors), 0)
+        first_key = list(diag.step_errors.keys())[0]
+        self.assertEqual(first_key.__class__.__name__, "Integrator")
+
+        #no implicit solver or algebraic loops
+        self.assertEqual(len(diag.solve_residuals), 0)
+        self.assertEqual(len(diag.loop_residuals), 0)
+
+    def test_worst_block(self):
+        src = Source(lambda t: 1.0)
+        i1 = Integrator()
+        i2 = Integrator()
+        sim = Simulation(
+            blocks=[src, i1, i2],
+            connections=[Connection(src, i1), Connection(i1, i2)],
+            dt=0.01,
+            diagnostics=True
+        )
+        sim.run(0.1)
+
+        result = sim.diagnostics.worst_block()
+        self.assertIsNotNone(result)
+        label, err = result
+        self.assertIn("Integrator", label)
+
+    def test_summary_string(self):
+        src = Source(lambda t: 1.0)
+        integ = Integrator()
+        sim = Simulation(
+            blocks=[src, integ],
+            connections=[Connection(src, integ)],
+            dt=0.01,
+            diagnostics=True
+        )
+        sim.run(0.1)
+
+        summary = sim.diagnostics.summary()
+        self.assertIn("Diagnostics at t", summary)
+        self.assertIn("Integrator", summary)
+
+    def test_reset_clears_diagnostics(self):
+        src = Source(lambda t: 1.0)
+        integ = Integrator()
+        sim = Simulation(
+            blocks=[src, integ],
+            connections=[Connection(src, integ)],
+            dt=0.01,
+            diagnostics=True
+        )
+        sim.run(0.1)
+        self.assertGreater(sim.diagnostics.time, 0)
+
+        sim.reset()
+        self.assertEqual(sim.diagnostics.time, 0.0)
+
+
+class TestDiagnosticsAdaptiveSolver(unittest.TestCase):
+    """Diagnostics with an adaptive solver."""
+
+    def test_adaptive_step_errors(self):
+        from pathsim.solvers import RKCK54
+
+        src = Source(lambda t: np.sin(10 * t))
+        integ = Integrator()
+        sim = Simulation(
+            blocks=[src, integ],
+            connections=[Connection(src, integ)],
+            dt=0.1,
+            Solver=RKCK54,
+            tolerance_lte_abs=1e-6,
+            tolerance_lte_rel=1e-4,
+            diagnostics=True
+        )
+        sim.run(1.0)
+
+        diag = sim.diagnostics
+        self.assertIsInstance(diag, Diagnostics)
+        self.assertGreater(len(diag.step_errors), 0)
+
+
+class TestDiagnosticsImplicitSolver(unittest.TestCase):
+    """Diagnostics with an implicit solver (solve residuals)."""
+
+    def test_implicit_solve_residuals(self):
+        from pathsim.solvers import ESDIRK32
+
+        src = Source(lambda t: np.sin(t))
+        integ = Integrator()
+        sim = Simulation(
+            blocks=[src, integ],
+            connections=[Connection(src, integ)],
+            dt=0.01,
+            Solver=ESDIRK32,
+            diagnostics=True
+        )
+        sim.run(0.1)
+
+        diag = sim.diagnostics
+        self.assertIsInstance(diag, Diagnostics)
+        self.assertGreater(len(diag.solve_residuals), 0)
+        self.assertGreater(diag.solve_iterations, 0)
+
+        #worst_block should find the block from solve residuals
+        result = diag.worst_block()
+        self.assertIsNotNone(result)
+
+        #summary should include implicit solver section
+        summary = diag.summary()
+        self.assertIn("Implicit solver residuals", summary)
+
+
+class TestDiagnosticsAlgebraicLoop(unittest.TestCase):
+    """Diagnostics with algebraic loops (loop residuals)."""
+
+    def test_algebraic_loop_residuals(self):
+        src = Source(lambda t: 1.0)
+        P1 = Adder()
+        A1 = Amplifier(0.5)
+        sco = Scope()
+
+        sim = Simulation(
+            blocks=[src, P1, A1, sco],
+            connections=[
+                Connection(src, P1),
+                Connection(P1, A1, sco),
+                Connection(A1, P1[1]),
+            ],
+            dt=0.01,
+            diagnostics=True
+        )
+
+        self.assertTrue(sim.graph.has_loops)
+        sim.run(0.05)
+
+        diag = sim.diagnostics
+        self.assertGreater(len(diag.loop_residuals), 0)
+
+        result = diag.worst_booster()
+        self.assertIsNotNone(result)
+
+        #summary should include algebraic loop section
+        summary = diag.summary()
+        self.assertIn("Algebraic loop residuals", summary)
+
+
+class TestDiagnosticsHistory(unittest.TestCase):
+    """Diagnostics history recording."""
+
+    def test_no_history_by_default(self):
+        src = Source(lambda t: 1.0)
+        integ = Integrator()
+        sim = Simulation(
+            blocks=[src, integ],
+            connections=[Connection(src, integ)],
+            dt=0.01,
+            diagnostics=True
+        )
+        sim.run(0.1)
+
+        self.assertIsNone(sim._diagnostics_history)
+        self.assertIsInstance(sim.diagnostics, Diagnostics)
+
+    def test_history_enabled(self):
+        src = Source(lambda t: 1.0)
+        integ = Integrator()
+        sim = Simulation(
+            blocks=[src, integ],
+            connections=[Connection(src, integ)],
+            dt=0.01,
+            diagnostics="history"
+        )
+        sim.run(0.1)
+
+        #should have ~10 snapshots (0.1s / 0.01 dt)
+        self.assertGreater(len(sim._diagnostics_history), 5)
+
+        #each snapshot should have a time
+        times = [s.time for s in sim._diagnostics_history]
+        self.assertEqual(times, sorted(times))
+
+    def test_history_reset(self):
+        src = Source(lambda t: 1.0)
+        integ = Integrator()
+        sim = Simulation(
+            blocks=[src, integ],
+            connections=[Connection(src, integ)],
+            dt=0.01,
+            diagnostics="history"
+        )
+        sim.run(0.05)
+        self.assertGreater(len(sim._diagnostics_history), 0)
+
+        sim.reset()
+        self.assertEqual(len(sim._diagnostics_history), 0)
+
+
+class TestDiagnosticsUnit(unittest.TestCase):
+    """Unit tests for the Diagnostics dataclass."""
+
+    def test_defaults(self):
+        d = Diagnostics()
+        self.assertEqual(d.time, 0.0)
+        self.assertIsNone(d.worst_block())
+        self.assertIsNone(d.worst_booster())
+
+    def test_worst_block_from_step_errors(self):
+
+        class FakeBlock:
+            pass
+
+        b1, b2 = FakeBlock(), FakeBlock()
+        d = Diagnostics(step_errors={b1: (True, 1e-3, 0.9), b2: (True, 5e-3, 0.7)})
+
+        label, err = d.worst_block()
+        self.assertAlmostEqual(err, 5e-3)
+
+    def test_worst_block_from_solve_residuals(self):
+
+        class FakeBlock:
+            pass
+
+        b1, b2 = FakeBlock(), FakeBlock()
+        d = Diagnostics(solve_residuals={b1: 1e-4, b2: 3e-3})
+
+        label, err = d.worst_block()
+        self.assertAlmostEqual(err, 3e-3)
+
+    def test_summary_with_all_data(self):
+
+        class FakeBlock:
+            pass
+
+        class FakeBooster:
+            class connection:
+                def __str__(self):
+                    return "A -> B"
+            connection = connection()
+
+        b = FakeBlock()
+        bst = FakeBooster()
+        d = Diagnostics(
+            time=1.0,
+            step_errors={b: (True, 1e-4, 0.9)},
+            solve_residuals={b: 1e-8},
+            solve_iterations=3,
+            loop_residuals={bst: 1e-12},
+            loop_iterations=2,
+        )
+
+        summary = d.summary()
+        self.assertIn("Diagnostics at t", summary)
+        self.assertIn("Adaptive step errors", summary)
+        self.assertIn("Implicit solver residuals", summary)
+        self.assertIn("Algebraic loop residuals", summary)
+
+
+class TestConvergenceTrackerUnit(unittest.TestCase):
+    """Unit tests for ConvergenceTracker."""
+
+    def test_record_and_converge(self):
+        t = ConvergenceTracker()
+        t.record("a", 1e-5)
+        t.record("b", 1e-8)
+        self.assertAlmostEqual(t.max_error, 1e-5)
+        self.assertTrue(t.converged(1e-4))
+        self.assertFalse(t.converged(1e-6))
+
+    def test_begin_iteration_clears(self):
+        t = ConvergenceTracker()
+        t.record("a", 1.0)
+        t.begin_iteration()
+        self.assertEqual(len(t.errors), 0)
+        self.assertEqual(t.max_error, 0.0)
+
+    def test_details(self):
+        t = ConvergenceTracker()
+        t.record("block_a", 1e-3)
+        t.record("block_b", 2e-4)
+        lines = t.details(lambda obj: f"name:{obj}")
+        self.assertEqual(len(lines), 2)
+        self.assertIn("name:block_a", lines[0])
+
+
+class TestStepTrackerUnit(unittest.TestCase):
+    """Unit tests for StepTracker."""
+
+    def test_record_aggregation(self):
+        t = StepTracker()
+        t.record("a", True, 1e-4, 0.9)
+        t.record("b", False, 2e-3, 0.5)
+        t.record("c", True, 1e-5, None)
+
+        self.assertFalse(t.success)
+        self.assertAlmostEqual(t.max_error, 2e-3)
+        self.assertAlmostEqual(t.scale, 0.5)
+
+    def test_scale_default(self):
+        t = StepTracker()
+        t.record("a", True, 0.0, None)
+        self.assertEqual(t.scale, 1.0)
+
+    def test_reset(self):
+        t = StepTracker()
+        t.record("a", False, 1.0, 0.1)
+        t.reset()
+        self.assertTrue(t.success)
+        self.assertEqual(t.max_error, 0.0)
+        self.assertEqual(len(t.errors), 0)


### PR DESCRIPTION
- Track per-block and per-connection convergence residuals in `_solve`, `_step`, and `_loops` — always available for error messages, zero overhead
- Enrich convergence failure messages with per-block/connection breakdown:
  - Algebraic loop `RuntimeError` lists per-connection residuals
  - Implicit solver non-convergence: `WARNING` with per-block residuals (both adaptive revert and fixed step)
  - Steadystate failure: `RuntimeError` with per-block residuals
- Optional `Diagnostics` snapshot via `Simulation(..., diagnostics=True)` — exposes `worst_block()`, `worst_booster()`, `summary()`
- Optional per-timestep history via `diagnostics="history"`

Closes #172
