### PR TITLE
Resolve connection port indices during graph assembly

### DIFF
--- a/src/pathsim/connection.py
+++ b/src/pathsim/connection.py
@@ -249,6 +249,30 @@ class Connection:
             self.source.to(trg)
 
 
+    def resolve_ports(self):
+        """Eagerly resolve source and target port indices, growing the
+        underlying ``Register`` instances to their final size.
+
+        Normally registers grow lazily on the first ``connection.update()``
+        via ``PortReference._get_input_indices``. In the DAG case that is
+        fine: the source-side connection fires before the target block's
+        ``update``, so by the time the block reads its inputs, the
+        register has the right size. Inside an algebraic loop the order
+        is reversed (``block.update()`` first, then ``connection.update()``
+        in the same iteration), so the first iteration sees a register
+        still at the ``Block.__init__`` default size and any block that
+        accesses inputs by position (e.g. ``Function`` splatting into a
+        multi-arg callable) raises ``TypeError``.
+
+        Calling ``resolve_ports`` once during graph assembly closes that
+        gap. Idempotent. New register slots are zero-initialised through
+        ``np.zeros`` in ``Register.resize``.
+        """
+        self.source._get_output_indices()
+        for trg in self.targets:
+            trg._get_input_indices()
+
+
 @deprecated(version="1.0.0")
 class Duplex(Connection):
     """Extension of the 'Connection' class, that defines bidirectional

--- a/src/pathsim/simulation.py
+++ b/src/pathsim/simulation.py
@@ -695,6 +695,11 @@ class Simulation:
             self.graph = Graph(self.blocks, self.connections)
         self._graph_dirty = False
 
+        #resolve all port indices so input/output registers are sized
+        #before any block.update() runs (see Connection.resolve_ports)
+        for con in self.connections:
+            con.resolve_ports()
+
         #create boosters for loop closing connections
         if self.graph.has_loops:
             self.boosters = [

--- a/tests/pathsim/test_connection.py
+++ b/tests/pathsim/test_connection.py
@@ -141,7 +141,7 @@ class TestConnection(unittest.TestCase):
 
 
     def test_on_off_bool(self):
-        
+
         B1, B2 = Block(), Block()
 
         #default
@@ -157,6 +157,62 @@ class TestConnection(unittest.TestCase):
         #activate
         C.on()
         self.assertTrue(C)
+
+
+    def test_resolve_ports_grows_input_register(self):
+        """resolve_ports must size the target input register so blocks
+        accessing inputs by position before any connection.update() runs
+        (e.g. inside an algebraic loop) see the correct number of slots.
+        """
+        B1, B2 = Block(), Block()
+
+        #fresh block has size-1 input register from Block.__init__
+        self.assertEqual(len(B2.inputs), 1)
+
+        C = Connection(B1[2], B2[3])
+
+        #ports validated but lazy resize not yet triggered
+        self.assertEqual(len(B2.inputs), 1)
+        self.assertEqual(len(B1.outputs), 1)
+
+        C.resolve_ports()
+
+        #both registers must accommodate the highest port index
+        self.assertEqual(len(B2.inputs), 4)
+        self.assertEqual(len(B1.outputs), 3)
+
+        #new slots are zero-initialised
+        self.assertEqual(B2.inputs[3], 0.0)
+
+
+    def test_resolve_ports_is_idempotent(self):
+        """Repeated calls must not change register size or contents."""
+        B1, B2 = Block(), Block()
+        C = Connection(B1[5], B2[7])
+
+        C.resolve_ports()
+        size_in = len(B2.inputs)
+        size_out = len(B1.outputs)
+
+        #seed a value so we can detect data loss on a second resolve
+        B2.inputs[7] = 42.0
+
+        C.resolve_ports()
+        self.assertEqual(len(B2.inputs), size_in)
+        self.assertEqual(len(B1.outputs), size_out)
+        self.assertEqual(B2.inputs[7], 42.0)
+
+
+    def test_resolve_ports_multi_target(self):
+        """All targets must be resolved, not just the first."""
+        B1, B2, B3 = Block(), Block(), Block()
+        C = Connection(B1[1], B2[4], B3[6])
+
+        C.resolve_ports()
+
+        self.assertEqual(len(B1.outputs), 2)
+        self.assertEqual(len(B2.inputs), 5)
+        self.assertEqual(len(B3.inputs), 7)
 
 
 

--- a/tests/pathsim/test_simulation.py
+++ b/tests/pathsim/test_simulation.py
@@ -21,9 +21,11 @@ from pathsim.connection import Connection
 #modules from pathsim for test case
 from pathsim.blocks import (
     Integrator,
-    Amplifier,  
-    Scope, 
-    Adder
+    Amplifier,
+    Scope,
+    Adder,
+    Function,
+    Constant,
     )
 
 from pathsim._constants import (
@@ -1043,6 +1045,65 @@ class TestSimulationRuntimeMutation(unittest.TestCase):
         # Integration result should reflect the change
         time, data = self.Sco.read()
         self.assertGreater(len(time), 0)
+
+
+class TestSimulationAlgebraicLoop(unittest.TestCase):
+    """Regression tests for algebraic-loop port resolution.
+
+    In an algebraic loop the iteration order is block.update() ->
+    connection.update(). Without eager port resolution during graph
+    assembly the first iteration would see input registers still at
+    their Block.__init__ default size, and any block accessing inputs
+    by position (Function splatting into a multi-arg lambda) would
+    raise TypeError.
+    """
+
+    def test_function_in_algebraic_loop_runs(self):
+        """Function with multi-arg lambda inside algebraic loop must run."""
+
+        c = Constant(value=1.0)
+        A = Function(lambda u, fb: u + 0.1 * fb)
+        B = Function(lambda x: 0.5 * x)
+
+        blocks = [c, A, B]
+        connections = [
+            Connection(c, A[0]),
+            Connection(A, B),
+            Connection(B, A[1]),    # closes the loop
+            ]
+
+        Sim = Simulation(blocks, connections, dt=0.01, log=False)
+
+        #without eager resolution this would raise TypeError on the first
+        #step ("missing 1 required positional argument: 'fb'")
+        Sim.run(duration=0.05)
+
+        #fixed point: A = 1 + 0.1 * 0.5 * A  ->  A = 1 / 0.95
+        self.assertAlmostEqual(float(A.outputs[0]), 1.0 / 0.95, 6)
+
+
+    def test_assemble_graph_resolves_all_connections(self):
+        """After Simulation init every connection's registers are sized."""
+
+        c = Constant(value=1.0)
+        A = Function(lambda u, fb: u + fb)
+        B = Function(lambda x: x)
+
+        blocks = [c, A, B]
+        connections = [
+            Connection(c, A[0]),
+            Connection(A, B),
+            Connection(B, A[1]),
+            ]
+
+        Simulation(blocks, connections, dt=0.01, log=False)
+
+        #all registers must reach their final size during _assemble_graph
+        self.assertGreaterEqual(len(A.inputs), 2)
+        self.assertGreaterEqual(len(B.inputs), 1)
+        self.assertGreaterEqual(len(c.outputs), 1)
+        self.assertGreaterEqual(len(A.outputs), 1)
+        self.assertGreaterEqual(len(B.outputs), 1)
 
 
 # RUN TESTS LOCALLY ====================================================================


### PR DESCRIPTION
## Problem

`Function` blocks (and any block accessing inputs by position) raise `TypeError: missing N required positional arguments` when placed inside an algebraic loop. Minimal repro:

```python
from pathsim import Simulation, Connection
from pathsim.blocks import Function, Constant
from pathsim.solvers import RKDP54

c = Constant(value=1.0)
A = Function(lambda u, fb: u + 0.1*fb)
B = Function(lambda x: 0.5*x)

sim = Simulation(
    [c, A, B],
    [Connection(c, A[0]), Connection(A, B), Connection(B, A[1])],
    dt=0.01, Solver=RKDP54,
)
sim.run(0.1)
# TypeError: <lambda>() missing 1 required positional argument: 'fb'
```

## Cause

`Block.__init__` creates input/output `Register`s at size 1. Registers grow lazily on the first `connection.update()` via `PortReference._get_input_indices`. In the DAG path that is fine — the source-side `connection.update()` fires before the target block's `update`. Inside an algebraic loop the iteration order in `Simulation._loops` is reversed:

```python
for block in blocks_loop:
    if block: block.update(t)            # reads inputs.to_array()
for connection in connections_loop:
    if connection: connection.update()   # only here would resize fire
```

So the first iteration sees a size-1 register and `Function`'s `func(*x)` splat raises.

## Fix

New `Connection.resolve_ports()` method that eagerly resolves source/target port indices, growing the registers to their final size. Called once per connection in `Simulation._assemble_graph` right after the graph is built. Idempotent. New register slots are zero-initialised through the existing `np.zeros` in `Register.resize`, so no explicit data write is needed.