### PR TITLE
Add StopSimulation, exceptions module

### DIFF
--- a/src/pathsim/__init__.py
+++ b/src/pathsim/__init__.py
@@ -9,3 +9,4 @@ from .simulation import Simulation
 from .connection import Connection, Duplex
 from .subsystem import Subsystem, Interface
 from .utils.logger import LoggerManager
+from .exceptions import StopSimulation

--- a/src/pathsim/exceptions.py
+++ b/src/pathsim/exceptions.py
@@ -1,0 +1,44 @@
+#########################################################################################
+##
+##                              PATHSIM EXCEPTIONS
+##                               (exceptions.py)
+##
+##      This module defines custom exceptions for the PathSim simulation framework.
+##
+#########################################################################################
+
+
+class StopSimulation(Exception):
+    """Exception that can be raised by blocks or models to signal that the 
+    simulation should stop immediately.
+
+    This provides a clean mechanism for user-defined stopping conditions,
+    such as reaching a target state, detecting a fault, or satisfying 
+    a convergence criterion.
+
+    When raised inside a block's update, sample, or any other method 
+    called during the simulation loop, the 'Simulation' class will catch 
+    it gracefully and terminate the run as if 'stop()' had been called.
+
+    Parameters
+    ----------
+    message : str
+        optional message describing the stopping condition
+
+    Example
+    -------
+
+    Raise from inside a block to stop the simulation:
+
+    .. code-block:: python
+
+        from pathsim.exceptions import StopSimulation
+        from pathsim.blocks import Function
+
+        def check(x):
+            if x > 10.0:
+                raise StopSimulation(f"value exceeded threshold: {x:.4f}")
+            return x
+
+        blk = Function(check)
+    """

--- a/src/pathsim/simulation.py
+++ b/src/pathsim/simulation.py
@@ -47,6 +47,7 @@ from .blocks._block import Block
 from .events._event import Event
 
 from .connection import Connection
+from .exceptions import StopSimulation
 
 
 # TRANSIENT SIMULATION CLASS ============================================================
@@ -1631,16 +1632,22 @@ class Simulation:
         _dt = self.dt
 
         #initial system function evaluation
-        self._update(self.time)
-
-        #catch and resolve initial events
-        for event, *_ in self._detected_events(self.time):
-
-            #resolve events directly
-            event.resolve(self.time)
-
-            #evaluate system function again -> propagate event
+        try:
             self._update(self.time)
+
+            #catch and resolve initial events
+            for event, *_ in self._detected_events(self.time):
+
+                #resolve events directly
+                event.resolve(self.time)
+
+                #evaluate system function again -> propagate event
+                self._update(self.time)
+
+        except StopSimulation as e:
+            self.logger.info(f"STOP (StopSimulation: '{e}')")
+            self._active = False
+            return
 
         #sampling states and inputs at 'self.time == starting_time'
         self._sample(self.time, _dt)
@@ -1649,10 +1656,15 @@ class Simulation:
         while self.time < end_time and self._active:
 
             #advance the simulation by one (effective) timestep '_dt'
-            success, error_norm, scale, *_ = self.timestep(
-                dt=_dt,
-                adaptive=_adaptive
-                )
+            try:
+                success, error_norm, scale, *_ = self.timestep(
+                    dt=_dt,
+                    adaptive=_adaptive
+                    )
+            except StopSimulation as e:
+                self.logger.info(f"STOP (StopSimulation: '{e}')")
+                self._active = False
+                break
 
             #perform adaptive rescale
             if _adaptive:

--- a/tests/pathsim/test_simulation.py
+++ b/tests/pathsim/test_simulation.py
@@ -39,6 +39,7 @@ from pathsim._constants import (
 from pathsim.blocks import Source, Relay
 from pathsim.events.schedule import Schedule
 from pathsim.events._event import Event
+from pathsim.exceptions import StopSimulation
 
 
 # TESTS ================================================================================
@@ -754,6 +755,82 @@ class TestSimulationAdvanced(unittest.TestCase):
 
         #simulation should have stopped early
         self.assertLess(self.Sim.time, 5.0)
+
+
+    def test_stop_simulation_exception_stops_run(self):
+        """StopSimulation raised by a block stops run() without propagating"""
+
+        threshold = 0.5  # Int state starts at 1 and decays — stop when below this
+
+        def guard(x):
+            if x < threshold:
+                raise StopSimulation(f"value dropped below {threshold}")
+            return x
+
+        guard_block = Function(guard)
+        self.Sim.add_block(guard_block)
+        self.Sim.add_connection(Connection(self.Int, guard_block))
+
+        # should not raise, and should stop before duration=5
+        self.Sim.run(duration=5.0, reset=True)
+
+        self.assertFalse(self.Sim._active)
+        self.assertLess(self.Sim.time, 5.0)
+
+
+    def test_stop_simulation_at_first_step(self):
+        """StopSimulation raised immediately leaves sim.time at start"""
+
+        call_count = [0]
+
+        def always_stop(x):
+            call_count[0] += 1
+            raise StopSimulation("stop immediately")
+
+        guard_block = Function(always_stop)
+        self.Sim.add_block(guard_block)
+        self.Sim.add_connection(Connection(self.Int, guard_block))
+
+        start_time = self.Sim.time
+        self.Sim.run(duration=5.0, reset=False)
+
+        self.assertFalse(self.Sim._active)
+        self.assertEqual(self.Sim.time, start_time)
+
+
+    def test_stop_simulation_exception_stops_run_streaming(self):
+        """StopSimulation raised by a block terminates run_streaming cleanly"""
+
+        threshold = 0.5
+
+        def guard(x):
+            if x < threshold:
+                raise StopSimulation("streaming stop")
+            return x
+
+        guard_block = Function(guard)
+        self.Sim.add_block(guard_block)
+        self.Sim.add_connection(Connection(self.Int, guard_block))
+
+        results = list(self.Sim.run_streaming(
+            duration=5.0,
+            reset=True,
+            tickrate=100,
+            func_callback=lambda: self.Sim.time
+        ))
+
+        self.assertFalse(self.Sim._active)
+        self.assertLess(self.Sim.time, 5.0)
+        self.assertGreater(len(results), 0)
+
+
+    def test_stop_simulation_no_exception_normal_run(self):
+        """Regression: normal run without StopSimulation completes fully"""
+
+        self.Sim.run(duration=2.0, reset=True)
+
+        self.assertAlmostEqual(self.Sim.time, 2.0, 5)
+        self.assertTrue(self.Sim._active)
 
 
     def test_deprecated_timestep_methods(self):


### PR DESCRIPTION
Adds a new `exceptions` module with one member: `StopSimulation`, which can be raised by blocks to tell the calling `Simulation` to stop.

Context: https://github.com/pathsim/pathsim-batt/issues/11#issuecomment-4421475279