### PR TITLE
Pre-size block registers from declared port labels

### DIFF
--- a/src/pathsim/blocks/_block.py
+++ b/src/pathsim/blocks/_block.py
@@ -18,6 +18,32 @@ from ..utils.register import Register
 from ..utils.portreference import PortReference
 
 
+# HELPERS ===============================================================================
+
+def _labels_size(labels):
+    """Minimum register size required to hold all declared port labels.
+
+    Port labels map string aliases to integer port indices. The register has
+    to be large enough to address the highest declared index, otherwise blocks
+    with unconnected declared ports (e.g. a multi-input block placed without
+    connections) would default to the size 1 register and break positional
+    input access.
+
+    Parameters
+    ----------
+    labels : dict[str: int] | None
+        port label mapping (alias -> index)
+
+    Returns
+    -------
+    size : int | None
+        minimum register size, or None if no labels are declared
+    """
+    if not labels:
+        return None
+    return max(labels.values()) + 1
+
+
 # BASE BLOCK CLASS ======================================================================
 
 class Block:
@@ -84,11 +110,14 @@ class Block:
 
     def __init__(self):
 
-        #registers to hold input and output values
+        #registers to hold input and output values, pre-sized to the declared
+        #port labels so blocks with unconnected ports are still addressable
         self.inputs = Register(
+            size=_labels_size(self.input_port_labels),
             mapping=self.input_port_labels and self.input_port_labels.copy()
             )
         self.outputs = Register(
+            size=_labels_size(self.output_port_labels),
             mapping=self.output_port_labels and self.output_port_labels.copy()
             )
 

--- a/src/pathsim/simulation.py
+++ b/src/pathsim/simulation.py
@@ -691,15 +691,16 @@ class Simulation:
         for block in self.blocks:
             block.inputs.reset()
 
+        #resolve all port indices so input/output registers are sized before
+        #graph assembly evaluates block passthrough via len(block) and before
+        #any block.update() runs (see Connection.resolve_ports)
+        for con in self.connections:
+            con.resolve_ports()
+
         #time the graph construction
         with Timer(verbose=False) as T:
             self.graph = Graph(self.blocks, self.connections)
         self._graph_dirty = False
-
-        #resolve all port indices so input/output registers are sized
-        #before any block.update() runs (see Connection.resolve_ports)
-        for con in self.connections:
-            con.resolve_ports()
 
         #create boosters for loop closing connections
         if self.graph.has_loops:

--- a/tests/pathsim/blocks/test_block.py
+++ b/tests/pathsim/blocks/test_block.py
@@ -254,6 +254,33 @@ class TestBlock(unittest.TestCase):
         self.assertEqual(cache_info.misses, 1)
 
 
+    def test_register_sizing_from_port_labels(self):
+        """Registers are pre-sized to the declared port labels so blocks
+        with unconnected multi-port interfaces stay positionally addressable.
+        """
+
+        class _LabeledBlock(Block):
+            input_port_labels = {"a": 0, "b": 1}
+            output_port_labels = {"x": 0, "y": 1, "z": 2}
+
+        B = _LabeledBlock()
+
+        #registers sized to highest declared index + 1
+        self.assertEqual(len(B.inputs), 2)
+        self.assertEqual(len(B.outputs), 3)
+
+        #shape reflects declared ports even without connections
+        self.assertEqual(B.shape, (2, 3))
+
+        #all declared ports addressable and zero-initialized
+        self.assertEqual(B.inputs["b"], 0.0)
+        self.assertEqual(B.outputs["z"], 0.0)
+
+        #blocks without port labels keep the default size 1 registers
+        self.assertEqual(len(Block().inputs), 1)
+        self.assertEqual(len(Block().outputs), 1)
+
+
 # RUN TESTS LOCALLY ====================================================================
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Problem

A block that declares `input_port_labels` / `output_port_labels` (e.g. `Bubbler4` from `pathsim-chem` with 2 input ports) gets its `Register` created at the default size `1`. The port labels only supply the name→index mapping, not the size, so the register never grows unless a `Connection` resolves its port indices.

When such a block is placed without connections, graph assembly calls `len(block)` to detect algebraic passthrough. For `DynamicalSystem` this evaluates `op_alg.jac_u` with the size-1 input array, and any block whose algebraic function unpacks its inputs positionally (`sol, ins = u`) raises `ValueError: not enough values to unpack`.

Reported in pathsim/pathview#298 — minimal case is a single `Bubbler4` block with no connections.

## Fix

- `blocks/_block.py`: new `_labels_size()` helper; `Block.__init__` pre-sizes the input/output registers to the highest declared port index. Blocks without port labels keep the default size-1 register.
- `simulation.py`: `Connection.resolve_ports()` now runs *before* `Graph(...)` is built, so registers are correctly sized before graph assembly evaluates `len(block)` (and before any `block.update()`).