### PR TITLE
Deprecate FMU blocks: moved to pathsim-fmi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,9 +19,12 @@ requires-python = ">=3.8"
 dependencies = ["numpy>=1.15", "matplotlib>=3.1", "scipy>=1.2"]
 
 [project.optional-dependencies]
+# Both `rf` and `fmi` are deprecated as of v0.22 — the corresponding blocks
+# have moved to their own toolboxes (pathsim-rf, pathsim-fmi) and the extras
+# will be removed in v1.0.0. Install the toolboxes directly instead.
 rf = ["scikit-rf"]
-test = ["pytest", "pytest-cov", "pytest-xdist", "FMPy", "scikit-rf"]
 fmi = ["FMPy"]
+test = ["pytest", "pytest-cov", "pytest-xdist", "FMPy", "scikit-rf"]
 
 [project.urls]
 Homepage = "https://github.com/pathsim/pathsim"

--- a/src/pathsim/blocks/fmu.py
+++ b/src/pathsim/blocks/fmu.py
@@ -15,10 +15,16 @@ from .dynsys import DynamicalSystem
 from ..events.schedule import Schedule, ScheduleList
 from ..events.zerocrossing import ZeroCrossing
 from ..utils.fmuwrapper import FMUWrapper
+from ..utils.deprecation import deprecated
 
 
 # BLOCKS ================================================================================
 
+@deprecated(
+    version="1.0.0",
+    replacement="pathsim_fmi.CoSimulationFMU",
+    reason="This block has moved to the pathsim-fmi package: pip install pathsim-fmi",
+)
 class CoSimulationFMU(Block):
     """Co-Simulation FMU block using FMPy with support for FMI 2.0 and FMI 3.0.
 
@@ -105,6 +111,11 @@ class CoSimulationFMU(Block):
         return 0
 
 
+@deprecated(
+    version="1.0.0",
+    replacement="pathsim_fmi.ModelExchangeFMU",
+    reason="This block has moved to the pathsim-fmi package: pip install pathsim-fmi",
+)
 class ModelExchangeFMU(DynamicalSystem):
     """Model Exchange FMU block using FMPy with support for FMI 2.0 and FMI 3.0.
 


### PR DESCRIPTION
Mark `CoSimulationFMU` and `ModelExchangeFMU` with the same `@deprecated(version="1.0.0", replacement="pathsim_fmi.…")` decorator already used for the RF block. The blocks now live in `pathsim/pathsim-fmi` (v0.1.0 on PyPI).

The `[fmi]` and `[rf]` extras in `pyproject.toml` are flagged in a comment as deprecated; both extras plus `blocks/fmu.py`, `blocks/rf.py` and `utils/fmuwrapper.py` get removed in v1.0.0.