### PR TITLE
Add AlgebraicConstraint block

### DIFF
--- a/src/pathsim/blocks/__init__.py
+++ b/src/pathsim/blocks/__init__.py
@@ -1,4 +1,5 @@
 from .differentiator import *
+from .constraint import *
 from .integrator import *
 from .multiplier import *
 from .divider import *

--- a/src/pathsim/blocks/constraint.py
+++ b/src/pathsim/blocks/constraint.py
@@ -1,0 +1,164 @@
+#########################################################################################
+##
+##                            ALGEBRAIC CONSTRAINT BLOCK
+##                              (pathsim/blocks/constraint.py)
+##
+#########################################################################################
+
+# IMPORTS ===============================================================================
+
+import numpy as np
+
+from ._block import Block
+
+from ..optim.newton import NewtonRaphson
+
+
+# BLOCKS ================================================================================
+
+class AlgebraicConstraint(Block):
+    """Solve a nonlinear algebraic constraint for its internal unknown.
+
+    At every evaluation the block solves the square nonlinear system
+
+    .. math::
+
+        \\mathrm{func}(x, u) = 0
+
+    for the internal unknown :math:`x` given the current block input :math:`u`,
+    and exposes the converged :math:`x` at its output:
+
+    .. math::
+
+        y = x \\quad\\text{such that}\\quad \\mathrm{func}(x, u) = 0
+
+
+    The constraint is resolved with an internal damped Newton-Raphson iteration
+    (:class:`.NewtonRaphson`) that is warm-started with the solution of the
+    previous evaluation, so typically only a couple of iterations are required.
+    If no analytical Jacobian :math:`\\partial \\mathrm{func} / \\partial x` is
+    supplied it is approximated by central finite differences.
+
+    This is the building block for steady-state operating points, implicit
+    constitutive laws, chemical / phase equilibria and quasi-steady-state
+    approximations, where an output is defined implicitly rather than
+    explicitly. The input :math:`u` is wired dynamically through the block
+    ports, so no input dimension has to be declared in advance.
+
+    Note
+    ----
+    This block is purely algebraic. Its constraint solve is part of the
+    algebraic component of the global system DAE and is therefore evaluated
+    multiple times per timestep, each time `Simulation._update(t)` is called.
+    The residual `func` must be purely algebraic and must not introduce states,
+    delay or other dynamic behaviour.
+
+    Example
+    -------
+    Compute the square root of the input as the positive root of
+    :math:`x^2 - u = 0`:
+
+    .. code-block:: python
+
+        import numpy as np
+        from pathsim.blocks import AlgebraicConstraint
+
+        #residual of the constraint x**2 - u = 0
+        def func(x, u):
+            return x**2 - u
+
+        ac = AlgebraicConstraint(func, x0=1.0)
+
+
+    A vector valued example, the equilibrium of a simple reversible reaction
+    :math:`A \\rightleftharpoons B` with conservation :math:`x_A + x_B = u`:
+
+    .. code-block:: python
+
+        import numpy as np
+        from pathsim.blocks import AlgebraicConstraint
+
+        k_f, k_r = 2.0, 1.0
+
+        def func(x, u):
+            return np.array([
+                k_f*x[0] - k_r*x[1],   #reaction equilibrium
+                x[0] + x[1] - u[0]     #mass conservation
+                ])
+
+        ac = AlgebraicConstraint(func, x0=[0.5, 0.5])
+
+
+    Parameters
+    ----------
+    func : callable
+        residual function of the constraint with signature `func(x, u)` that
+        returns an array of the same dimension as `x`, where `x` is the
+        internal unknown and `u` is the block input array
+    x0 : float, array[float]
+        initial value / initial guess for the internal unknown `x`
+    jac : callable, None
+        optional analytical jacobian of `func` with respect to `x` with
+        signature `jac(x, u)`, central finite differences are used if `None`
+
+    Attributes
+    ----------
+    solver : NewtonRaphson
+        internal root solver for the algebraic constraint
+    """
+
+    def __init__(self, func=lambda x, u: x, x0=0.0, jac=None):
+        super().__init__()
+
+        #some checks to ensure that function works correctly
+        if not callable(func):
+            raise ValueError(f"'{func}' is not callable")
+
+        #residual function and optional jacobian of the constraint
+        self.func = func
+        self.jac = jac
+
+        #initial guess and warm-start for the internal unknown
+        self.x0 = np.atleast_1d(x0).astype(float)
+        self._x = self.x0.copy()
+
+        #internal root solver for the constraint
+        self.solver = NewtonRaphson()
+
+        #pre-size the output register to the unknown dimension
+        self.outputs.update_from_array(self._x)
+
+
+    def __len__(self):
+        return 1 if self._active else 0
+
+
+    def reset(self):
+        """Reset inputs, outputs and the warm-start of the internal unknown."""
+        super().reset()
+        self._x = self.x0.copy()
+        self.outputs.update_from_array(self._x)
+
+
+    def update(self, t):
+        """Solve the algebraic constraint for the current input and set the
+        output to the converged internal unknown.
+
+        Parameters
+        ----------
+        t : float
+            evaluation time
+        """
+
+        #current block input
+        u = self.inputs.to_array()
+
+        #residual and optional jacobian as functions of x at fixed u
+        _func = lambda x: self.func(x, u)
+        _jac = None if self.jac is None else (lambda x: self.jac(x, u))
+
+        #solve the constraint, warm-started with the previous solution
+        self._x, _, _ = self.solver.solve(_func, self._x, _jac)
+
+        #expose the converged unknown
+        self.outputs.update_from_array(self._x)

--- a/tests/pathsim/blocks/test_constraint.py
+++ b/tests/pathsim/blocks/test_constraint.py
@@ -1,0 +1,151 @@
+########################################################################################
+##
+##                                  TESTS FOR
+##                            'blocks.constraint.py'
+##
+########################################################################################
+
+# IMPORTS ==============================================================================
+
+import unittest
+import numpy as np
+
+from pathsim.blocks.constraint import AlgebraicConstraint
+
+from tests.pathsim.blocks._embedding import Embedding
+
+
+# TESTS ================================================================================
+
+class TestAlgebraicConstraint(unittest.TestCase):
+    """
+    Test the implementation of the 'AlgebraicConstraint' block class
+    """
+
+    def test_init(self):
+
+        def func(x, u): return x**2 - u
+
+        AC = AlgebraicConstraint(func, x0=1.0)
+
+        #residual stored and callable
+        self.assertEqual(AC.func(2.0, 4.0), 0.0)
+
+        #initial guess as float array
+        np.testing.assert_array_equal(AC.x0, np.array([1.0]))
+        np.testing.assert_array_equal(AC._x, np.array([1.0]))
+
+        #output pre-sized to unknown dimension
+        self.assertEqual(len(AC.outputs), 1)
+
+        #input validation
+        for v in [2, 0.3, 1j, np.ones(3)]:
+            with self.assertRaises(ValueError):
+                AlgebraicConstraint(func=v)
+
+
+    def test_algebraic_path(self):
+        #purely algebraic block -> length 1 when active
+        AC = AlgebraicConstraint(lambda x, u: x**2 - u, x0=1.0)
+        self.assertEqual(len(AC), 1)
+        AC.off()
+        self.assertEqual(len(AC), 0)
+
+
+    def test_scalar_constraint(self):
+        #solve x**2 - u = 0 -> x = sqrt(u)
+        AC = AlgebraicConstraint(lambda x, u: x**2 - u, x0=1.0)
+
+        def src(t): return 2.0 + t          #positive input
+        def ref(t): return np.sqrt(2.0 + t)
+
+        E = Embedding(AC, src, ref)
+        for t in range(5):
+            out, exp = E.check_SISO(t)
+            self.assertAlmostEqual(float(out), exp, places=8)
+
+
+    def test_scalar_constraint_with_jac(self):
+        #same problem with analytical jacobian d/dx (x**2 - u) = 2x
+        AC = AlgebraicConstraint(
+            func=lambda x, u: x**2 - u,
+            x0=1.0,
+            jac=lambda x, u: 2.0 * x
+            )
+
+        def src(t): return 3.0 + t
+        def ref(t): return np.sqrt(3.0 + t)
+
+        E = Embedding(AC, src, ref)
+        for t in range(5):
+            out, exp = E.check_SISO(t)
+            self.assertAlmostEqual(float(out), exp, places=8)
+
+
+    def test_vector_constraint(self):
+        #reversible reaction equilibrium with mass conservation:
+        #   k_f*xA - k_r*xB = 0,  xA + xB = u  ->  xA = u*k_r/(k_f+k_r)
+        k_f, k_r = 2.0, 1.0
+
+        def func(x, u):
+            return np.array([k_f*x[0] - k_r*x[1], x[0] + x[1] - u[0]])
+
+        AC = AlgebraicConstraint(func, x0=[0.5, 0.5])
+
+        u = 6.0
+        AC.inputs[0] = u
+        AC.update(0.0)
+
+        xA = u * k_r / (k_f + k_r)
+        xB = u * k_f / (k_f + k_r)
+        np.testing.assert_allclose(AC.outputs.to_array(), [xA, xB], atol=1e-8)
+
+
+    def test_warmstart_and_reset(self):
+        AC = AlgebraicConstraint(lambda x, u: x**2 - u, x0=1.0)
+
+        #solve at u=4 -> x=2, warm-start advances
+        AC.inputs[0] = 4.0
+        AC.update(0.0)
+        self.assertAlmostEqual(float(AC._x[0]), 2.0, places=8)
+
+        #reset restores the initial guess and output
+        AC.reset()
+        np.testing.assert_array_equal(AC._x, AC.x0)
+        np.testing.assert_array_equal(AC.outputs.to_array(), AC.x0)
+
+
+    def test_info(self):
+        #metadata introspection is available like for every block
+        info = AlgebraicConstraint.info()
+        self.assertEqual(info["type"], "AlgebraicConstraint")
+        self.assertIn("func", info["parameters"])
+        self.assertIn("x0", info["parameters"])
+        self.assertIn("jac", info["parameters"])
+
+
+    def test_simulation_steady_state(self):
+        #drive the constraint with a constant source and integrate a bit:
+        #the output must equal the implicit solution sqrt(u) throughout
+        from pathsim import Simulation, Connection
+        from pathsim.blocks import Constant, Scope
+
+        src = Constant(2.0)
+        ac = AlgebraicConstraint(lambda x, u: x**2 - u, x0=1.0)
+        sco = Scope()
+
+        sim = Simulation(
+            blocks=[src, ac, sco],
+            connections=[Connection(src, ac), Connection(ac, sco)],
+            log=False
+            )
+        sim.run(1.0)
+
+        time, [data] = sco.read()
+        np.testing.assert_allclose(data, np.sqrt(2.0), atol=1e-6)
+
+
+# RUN TESTS LOCALLY ====================================================================
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Adds the `AlgebraicConstraint` block (`blocks/constraint.py`), which solves a square nonlinear constraint `func(x, u) = 0` for an internal unknown `x` at every evaluation and exposes the converged `x` at its output.

- Internal warm-started Newton-Raphson solve (`optim.newton`), optional user Jacobian
- Dynamic input wiring, purely algebraic (integrates with the algebraic loop solver)
- Use cases: steady-state operating points, implicit constitutive laws, equilibria, quasi-steady-state

Builds on the NewtonRaphson solver. Fully tested incl. a simulation.