### PR TITLE
Add SemiExplicitDAE block

### DIFF
--- a/src/pathsim/blocks/__init__.py
+++ b/src/pathsim/blocks/__init__.py
@@ -1,5 +1,6 @@
 from .differentiator import *
 from .constraint import *
+from .dae import *
 from .integrator import *
 from .multiplier import *
 from .divider import *

--- a/src/pathsim/blocks/dae.py
+++ b/src/pathsim/blocks/dae.py
@@ -1,0 +1,271 @@
+#########################################################################################
+##
+##                       DIFFERENTIAL-ALGEBRAIC EQUATION BLOCKS
+##                                (pathsim/blocks/dae.py)
+##
+#########################################################################################
+
+# IMPORTS ===============================================================================
+
+import numpy as np
+
+from ._block import Block
+
+from ..optim.newton import NewtonRaphson
+from ..optim.numerical import num_jac
+
+
+# BLOCKS ================================================================================
+
+class SemiExplicitDAE(Block):
+    """Semi-explicit index-1 differential-algebraic equation (DAE) system.
+
+    Integrates a system that couples differential states :math:`x` to algebraic
+    states :math:`z` through an explicit constraint
+
+    .. math::
+
+        \\begin{align}
+            \\dot{x} &= f_\\mathrm{dyn}(x, z, u, t) \\\\
+                   0 &= f_\\mathrm{alg}(x, z, u, t)
+        \\end{align}
+
+
+    where :math:`u` is the block input. The constraint is assumed to be
+    index-1, i.e. the algebraic Jacobian :math:`\\partial f_\\mathrm{alg} /
+    \\partial z` is nonsingular, so the algebraic states are locally a function
+    :math:`z = z(x, u, t)` of the differential states.
+
+    At every evaluation the algebraic states are eliminated by an internal
+    Newton-Raphson iteration (:class:`.NewtonRaphson`) that solves
+    :math:`f_\\mathrm{alg}(x, z, u, t) = 0` for :math:`z`, warm-started with the
+    previous solution. The block then presents the reduced explicit right hand
+    side
+
+    .. math::
+
+        \\dot{x} = f_\\mathrm{dyn}(x, z(x, u, t), u, t)
+
+    to the integration engine, so the DAE integrates with any solver, explicit
+    or implicit. The block output is the stacked state :math:`[x, z]`.
+
+    Note
+    ----
+    The reduced Jacobian :math:`\\partial \\dot{x} / \\partial x` handed to
+    implicit solvers is obtained from central finite differences through the
+    eliminated constraint. An analytical Jacobian :math:`\\partial
+    f_\\mathrm{alg} / \\partial z` accelerates the inner constraint solve and
+    can be supplied via `jac_z`.
+
+    Example
+    -------
+    A pendulum in index-1 form, where the angular velocity follows the
+    differential equation and the tension is determined by the constraint:
+
+    .. code-block:: python
+
+        import numpy as np
+        from pathsim.blocks import SemiExplicitDAE
+
+        g, L = 9.81, 1.0
+
+        #x = [theta, omega], z = [tension]
+        def f_dyn(x, z, u, t):
+            theta, omega = x
+            return np.array([omega, -z[0]*np.sin(theta)])
+
+        def f_alg(x, z, u, t):
+            theta, omega = x
+            return np.array([z[0] - (g*np.cos(theta) + L*omega**2)])
+
+        dae = SemiExplicitDAE(f_dyn, f_alg, initial_value=[0.5, 0.0], z0=[1.0])
+
+
+    Parameters
+    ----------
+    func_dyn : callable
+        right hand side of the differential part with signature
+        `func_dyn(x, z, u, t)` returning the derivative of `x`
+    func_alg : callable
+        residual of the algebraic constraint with signature
+        `func_alg(x, z, u, t)` returning an array of the dimension of `z`
+    initial_value : float, array[float]
+        initial value / initial condition of the differential states `x`
+    z0 : float, array[float]
+        initial value / initial guess for the algebraic states `z`
+    jac_z : callable, None
+        optional analytical jacobian of `func_alg` with respect to `z` with
+        signature `jac_z(x, z, u, t)`, central finite differences are used if
+        `None`
+
+    Attributes
+    ----------
+    engine : Solver
+        numerical integration engine for the differential states `x`
+    solver : NewtonRaphson
+        internal root solver for the algebraic constraint
+    """
+
+    def __init__(
+        self,
+        func_dyn=lambda x, z, u, t: -x,
+        func_alg=lambda x, z, u, t: z,
+        initial_value=0.0,
+        z0=0.0,
+        jac_z=None
+        ):
+
+        super().__init__()
+
+        #differential and algebraic right hand side functions
+        self.func_dyn = func_dyn
+        self.func_alg = func_alg
+
+        #optional analytical jacobian of the constraint w.r.t. z
+        self.jac_z = jac_z
+
+        #initial condition of the differential states (drives the engine)
+        self.initial_value = np.atleast_1d(initial_value).astype(float)
+
+        #initial guess and warm-start of the algebraic states
+        self.z0 = np.atleast_1d(z0).astype(float)
+        self._z = self.z0.copy()
+
+        #internal root solver for the algebraic constraint
+        self.solver = NewtonRaphson()
+
+        #pre-size the output register to the stacked state [x, z]
+        self.outputs.update_from_array(
+            np.concatenate([self.initial_value, self.z0])
+            )
+
+
+    def __len__(self):
+        #the algebraic states generally depend on the input, so the block
+        #carries an algebraic passthrough through z
+        return 1 if self._active else 0
+
+
+    def reset(self):
+        """Reset inputs, outputs, the engine and the warm-start of the
+        algebraic states.
+        """
+        super().reset()
+        self._z = self.z0.copy()
+        x = self.engine.state if self.engine else self.initial_value
+        self.outputs.update_from_array(
+            np.concatenate([np.atleast_1d(x), self._z])
+            )
+
+
+    def _solve_z(self, x, u, t):
+        """Eliminate the algebraic states by solving the constraint
+        'func_alg(x, z, u, t) = 0' for z, warm-started with the previous
+        solution. Does not mutate the warm-start.
+
+        Parameters
+        ----------
+        x : array[float]
+            current differential states
+        u : array[float]
+            current block input
+        t : float
+            evaluation time
+
+        Returns
+        -------
+        z : array[float]
+            algebraic states satisfying the constraint
+        """
+        _func = lambda z: self.func_alg(x, z, u, t)
+        _jac = None if self.jac_z is None else (lambda z: self.jac_z(x, z, u, t))
+        z, _, _ = self.solver.solve(_func, self._z, _jac)
+        return z
+
+
+    def _rhs(self, x, u, t):
+        """Reduced explicit right hand side with the algebraic states
+        eliminated.
+
+        Parameters
+        ----------
+        x : array[float]
+            current differential states
+        u : array[float]
+            current block input
+        t : float
+            evaluation time
+
+        Returns
+        -------
+        dx : array[float]
+            derivative of the differential states
+        """
+        return self.func_dyn(x, self._solve_z(x, u, t), u, t)
+
+
+    def update(self, t):
+        """Eliminate the algebraic states for the current input and expose the
+        stacked state [x, z] at the output.
+
+        Parameters
+        ----------
+        t : float
+            evaluation time
+        """
+        x, u = self.engine.state, self.inputs.to_array()
+        self._z = self._solve_z(x, u, t)
+        self.outputs.update_from_array(
+            np.concatenate([np.atleast_1d(x), self._z])
+            )
+
+
+    def solve(self, t, dt):
+        """Advance the implicit update equation of the solver with the reduced
+        right hand side and its finite-difference Jacobian.
+
+        Parameters
+        ----------
+        t : float
+            evaluation time
+        dt : float
+            integration timestep
+
+        Returns
+        -------
+        error : float
+            solver residual norm
+        """
+        x, u = self.engine.state, self.inputs.to_array()
+
+        #commit the warm-start at the current state, then linearize around it
+        self._z = self._solve_z(x, u, t)
+        f = self.func_dyn(x, self._z, u, t)
+        J = num_jac(lambda _x: self._rhs(_x, u, t), x)
+
+        return self.engine.solve(f, J, dt)
+
+
+    def step(self, t, dt):
+        """Compute the timestep update with the reduced right hand side.
+
+        Parameters
+        ----------
+        t : float
+            evaluation time
+        dt : float
+            integration timestep
+
+        Returns
+        -------
+        success : bool
+            step was successful
+        error : float
+            local truncation error from adaptive integrators
+        scale : float
+            timestep rescale from adaptive integrators
+        """
+        x, u = self.engine.state, self.inputs.to_array()
+        self._z = self._solve_z(x, u, t)
+        f = self.func_dyn(x, self._z, u, t)
+        return self.engine.step(f, dt)

--- a/tests/pathsim/blocks/test_dae.py
+++ b/tests/pathsim/blocks/test_dae.py
@@ -1,0 +1,163 @@
+########################################################################################
+##
+##                                  TESTS FOR
+##                               'blocks.dae.py'
+##
+########################################################################################
+
+# IMPORTS ==============================================================================
+
+import unittest
+import numpy as np
+
+from pathsim.blocks.dae import SemiExplicitDAE
+
+from pathsim.solvers.esdirk43 import ESDIRK43
+
+
+# TESTS ================================================================================
+
+class TestSemiExplicitDAE(unittest.TestCase):
+    """
+    Test the implementation of the 'SemiExplicitDAE' block class.
+
+    Reference problem (scalar, autonomous):
+
+        x' = -x + z,   0 = z - x**2      =>   x' = x**2 - x
+
+    with x(0) = 0.5 this has the closed-form solution
+
+        x(t) = 1 / (1 + exp(t)),   z(t) = x(t)**2
+    """
+
+    def _make_block(self):
+        f_dyn = lambda x, z, u, t: -x + z
+        f_alg = lambda x, z, u, t: z - x**2
+        return SemiExplicitDAE(f_dyn, f_alg, initial_value=0.5, z0=0.25)
+
+    @staticmethod
+    def _exact(t):
+        x = 1.0 / (1.0 + np.exp(t))
+        return x, x**2
+
+
+    def test_init(self):
+        dae = self._make_block()
+
+        #differential initial condition drives the engine
+        np.testing.assert_array_equal(dae.initial_value, np.array([0.5]))
+
+        #algebraic warm-start
+        np.testing.assert_array_equal(dae.z0, np.array([0.25]))
+        np.testing.assert_array_equal(dae._z, np.array([0.25]))
+
+        #output pre-sized to the stacked state [x, z]
+        self.assertEqual(len(dae.outputs), 2)
+
+
+    def test_z_elimination(self):
+        #constraint z - x**2 = 0 -> z = x**2
+        dae = self._make_block()
+        z = dae._solve_z(np.array([0.3]), np.array([0.0]), 0.0)
+        self.assertAlmostEqual(float(z[0]), 0.09, places=8)
+
+
+    def test_reduced_rhs(self):
+        #reduced right hand side x' = -x + z = x**2 - x
+        dae = self._make_block()
+        dx = dae._rhs(np.array([0.3]), np.array([0.0]), 0.0)
+        self.assertAlmostEqual(float(dx[0]), 0.3**2 - 0.3, places=8)
+
+
+    def test_algebraic_path(self):
+        dae = self._make_block()
+        self.assertEqual(len(dae), 1)
+        dae.off()
+        self.assertEqual(len(dae), 0)
+
+
+    def test_jac_z_matches_numerical(self):
+        #analytical jac_z must give the same elimination as the FD fallback
+        f_dyn = lambda x, z, u, t: -x + z
+        f_alg = lambda x, z, u, t: z - x**2
+        jac_z = lambda x, z, u, t: np.array([[1.0]])
+
+        dae_num = SemiExplicitDAE(f_dyn, f_alg, 0.5, 0.25)
+        dae_ana = SemiExplicitDAE(f_dyn, f_alg, 0.5, 0.25, jac_z=jac_z)
+
+        x, u = np.array([0.4]), np.array([0.0])
+        np.testing.assert_allclose(
+            dae_num._solve_z(x, u, 0.0),
+            dae_ana._solve_z(x, u, 0.0),
+            atol=1e-10
+            )
+
+
+    def test_reset(self):
+        dae = self._make_block()
+        dae.set_solver(ESDIRK43, None)
+        dae._z = np.array([0.99])
+        dae.reset()
+        np.testing.assert_array_equal(dae._z, dae.z0)
+
+
+    def test_info(self):
+        info = SemiExplicitDAE.info()
+        self.assertEqual(info["type"], "SemiExplicitDAE")
+        for p in ("func_dyn", "func_alg", "initial_value", "z0", "jac_z"):
+            self.assertIn(p, info["parameters"])
+
+
+    def test_simulation_matches_analytic(self):
+        #integrate the DAE with an implicit solver and compare to the exact
+        #solution, exercising the reduced right hand side and its jacobian
+        from pathsim import Simulation, Connection
+        from pathsim.blocks import Scope
+
+        dae = self._make_block()
+        sco = Scope()
+
+        sim = Simulation(
+            blocks=[dae, sco],
+            connections=[Connection(dae[0], sco[0])],
+            dt=0.01,
+            Solver=ESDIRK43,
+            log=False
+            )
+        sim.run(2.0)
+
+        x_exact, z_exact = self._exact(2.0)
+        self.assertAlmostEqual(float(dae.engine.state[0]), x_exact, places=4)
+        self.assertAlmostEqual(float(dae._z[0]), z_exact, places=4)
+
+
+    def test_simulation_with_input(self):
+        #constraint pulls z to the input, the state relaxes to x -> u:
+        #   x' = -x + z,   0 = z - u   =>   x' = -x + u
+        from pathsim import Simulation, Connection
+        from pathsim.blocks import Constant, Scope
+
+        f_dyn = lambda x, z, u, t: -x + z
+        f_alg = lambda x, z, u, t: z - u
+
+        dae = SemiExplicitDAE(f_dyn, f_alg, initial_value=0.0, z0=0.0)
+        src = Constant(3.0)
+        sco = Scope()
+
+        sim = Simulation(
+            blocks=[src, dae, sco],
+            connections=[Connection(src, dae), Connection(dae[0], sco[0])],
+            dt=0.01,
+            Solver=ESDIRK43,
+            log=False
+            )
+        sim.run(20.0)
+
+        #relaxed to the steady state x -> u = 3
+        self.assertAlmostEqual(float(dae.engine.state[0]), 3.0, places=4)
+
+
+# RUN TESTS LOCALLY ====================================================================
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Adds the `SemiExplicitDAE` block (`blocks/dae.py`) for semi-explicit index-1 differential-algebraic systems:

```
x' = f_dyn(x, z, u, t)
0  = f_alg(x, z, u, t)
```

- Algebraic states `z` eliminated per evaluation by a warm-started inner Newton (`optim.newton`), optional user Jacobian `jac_z`
- Reduced explicit right hand side presented to the engine, so it integrates with any solver (no solver-core changes)
- Output is the stacked state `[x, z]`

Verified against an analytic index-1 reference solution.