### PR TITLE
Make algebraic/DAE blocks consistent with the ODE block

### DIFF
--- a/src/pathsim/blocks/constraint.py
+++ b/src/pathsim/blocks/constraint.py
@@ -11,7 +11,7 @@ import numpy as np
 
 from ._block import Block
 
-from ..optim.newton import NewtonRaphson
+from ..optim.anderson import NewtonAnderson, solve_root
 
 
 # BLOCKS ================================================================================
@@ -33,9 +33,10 @@ class AlgebraicConstraint(Block):
         y = x \\quad\\text{such that}\\quad \\mathrm{func}(x, u) = 0
 
 
-    The constraint is resolved with an internal damped Newton-Raphson iteration
-    (:class:`.NewtonRaphson`) that is warm-started with the solution of the
-    previous evaluation, so typically only a couple of iterations are required.
+    The constraint is resolved with an internal Anderson-accelerated damped
+    Newton iteration (:class:`.NewtonAnderson`) that is warm-started with the
+    solution of the previous evaluation, so typically only a couple of
+    iterations are required.
     If no analytical Jacobian :math:`\\partial \\mathrm{func} / \\partial x` is
     supplied it is approximated by central finite differences.
 
@@ -103,8 +104,8 @@ class AlgebraicConstraint(Block):
 
     Attributes
     ----------
-    solver : NewtonRaphson
-        internal root solver for the algebraic constraint
+    opt : NewtonAnderson
+        internal Newton-Anderson optimizer for the algebraic constraint
     """
 
     def __init__(self, func=lambda x, u: x, x0=0.0, jac=None):
@@ -122,8 +123,8 @@ class AlgebraicConstraint(Block):
         self.x0 = np.atleast_1d(x0).astype(float)
         self._x = self.x0.copy()
 
-        #internal root solver for the constraint
-        self.solver = NewtonRaphson()
+        #internal optimizer for the constraint (consistent with implicit solvers)
+        self.opt = NewtonAnderson()
 
         #pre-size the output register to the unknown dimension
         self.outputs.update_from_array(self._x)
@@ -158,7 +159,7 @@ class AlgebraicConstraint(Block):
         _jac = None if self.jac is None else (lambda x: self.jac(x, u))
 
         #solve the constraint, warm-started with the previous solution
-        self._x, _, _ = self.solver.solve(_func, self._x, _jac)
+        self._x, _, _ = solve_root(self.opt, _func, self._x, _jac)
 
         #expose the converged unknown
         self.outputs.update_from_array(self._x)

--- a/src/pathsim/blocks/dae.py
+++ b/src/pathsim/blocks/dae.py
@@ -11,8 +11,8 @@ import numpy as np
 
 from ._block import Block
 
-from ..optim.newton import NewtonRaphson
-from ..optim.numerical import num_jac
+from ..optim.operator import DynamicOperator
+from ..optim.anderson import NewtonAnderson, solve_root
 
 
 # BLOCKS ================================================================================
@@ -37,7 +37,7 @@ class SemiExplicitDAE(Block):
     :math:`z = z(x, u, t)` of the differential states.
 
     At every evaluation the algebraic states are eliminated by an internal
-    Newton-Raphson iteration (:class:`.NewtonRaphson`) that solves
+    Newton-Anderson iteration (:class:`.NewtonAnderson`) that solves
     :math:`f_\\mathrm{alg}(x, z, u, t) = 0` for :math:`z`, warm-started with the
     previous solution. The block then presents the reduced explicit right hand
     side
@@ -102,8 +102,11 @@ class SemiExplicitDAE(Block):
     ----------
     engine : Solver
         numerical integration engine for the differential states `x`
-    solver : NewtonRaphson
-        internal root solver for the algebraic constraint
+    op_dyn : DynamicOperator
+        dynamic operator wrapping the reduced right hand side, provides the
+        engine Jacobian like the `ODE` block
+    opt : NewtonAnderson
+        internal Newton-Anderson optimizer for the algebraic constraint
     """
 
     def __init__(
@@ -131,8 +134,12 @@ class SemiExplicitDAE(Block):
         self.z0 = np.atleast_1d(z0).astype(float)
         self._z = self.z0.copy()
 
-        #internal root solver for the algebraic constraint
-        self.solver = NewtonRaphson()
+        #internal optimizer for the algebraic constraint (consistent with engines)
+        self.opt = NewtonAnderson()
+
+        #dynamic operator for the reduced right hand side, mirrors the ODE block
+        #and supplies the engine Jacobian through 'op_dyn.jac_x'
+        self.op_dyn = DynamicOperator(func=self._rhs)
 
         #pre-size the output register to the stacked state [x, z]
         self.outputs.update_from_array(
@@ -179,7 +186,7 @@ class SemiExplicitDAE(Block):
         """
         _func = lambda z: self.func_alg(x, z, u, t)
         _jac = None if self.jac_z is None else (lambda z: self.jac_z(x, z, u, t))
-        z, _, _ = self.solver.solve(_func, self._z, _jac)
+        z, _, _ = solve_root(self.opt, _func, self._z, _jac)
         return z
 
 
@@ -222,7 +229,7 @@ class SemiExplicitDAE(Block):
 
     def solve(self, t, dt):
         """Advance the implicit update equation of the solver with the reduced
-        right hand side and its finite-difference Jacobian.
+        right hand side and its Jacobian from the dynamic operator.
 
         Parameters
         ----------
@@ -241,7 +248,7 @@ class SemiExplicitDAE(Block):
         #commit the warm-start at the current state, then linearize around it
         self._z = self._solve_z(x, u, t)
         f = self.func_dyn(x, self._z, u, t)
-        J = num_jac(lambda _x: self._rhs(_x, u, t), x)
+        J = self.op_dyn.jac_x(x, u, t)
 
         return self.engine.solve(f, J, dt)
 

--- a/src/pathsim/optim/__init__.py
+++ b/src/pathsim/optim/__init__.py
@@ -1,2 +1,3 @@
 from .operator import Operator
 from .newton import NewtonRaphson
+from .anderson import Anderson, NewtonAnderson, solve_root

--- a/src/pathsim/optim/anderson.py
+++ b/src/pathsim/optim/anderson.py
@@ -11,10 +11,14 @@ import numpy as np
 
 from collections import deque
 
+from .numerical import num_jac
+
 from .._constants import (
     TOLERANCE,
     OPT_RESTART,
-    OPT_HISTORY
+    OPT_HISTORY,
+    SOL_TOLERANCE_FPI,
+    SOL_ITERATIONS_MAX
     )
 
 
@@ -365,3 +369,109 @@ class NewtonAnderson(Anderson):
             y, _ = super().step(_x, g)
 
             return y, res_norm
+
+
+
+# ROOT SOLVING ========================================================================
+
+def _inf_norm(residual, x):
+    """Infinity norm of the residual at 'x'."""
+    return np.linalg.norm(np.atleast_1d(residual(x)), np.inf)
+
+
+def solve_root(opt, residual, x0, jac=None,
+               tolerance=SOL_TOLERANCE_FPI, iterations_max=SOL_ITERATIONS_MAX,
+               line_search_max=20):
+    """Solve the square nonlinear system :math:`F(x) = 0` by Anderson accelerated
+    damped Newton iteration.
+
+    Each iteration takes a Newton direction :math:`\\Delta x = J^{-1} F`,
+    damps it with a backtracking line search on the residual norm so the step
+    stays in the basin of the current root, and then accelerates the resulting
+    iterate with the Anderson optimizer
+
+    .. math::
+
+        \\tilde{x}_{k+1} = x_k - \\alpha_k J^{-1} F(x_k), \\qquad
+        x_{k+1} = \\mathrm{Anderson}(x_k, \\tilde{x}_{k+1})
+
+
+    The Anderson step is applied to the (damped) Newton iterate rather than to
+    the raw fixed-point map :math:`x + F(x)`, so the first iterate is already a
+    proper Newton step and cold starts do not jump out of the root's basin. The
+    accelerated iterate is kept only if it does not increase the residual,
+    otherwise the plain Newton iterate is used, which makes the acceleration
+    safe. The optimizer instance is the same Newton-Anderson type the implicit
+    engines use, so the algebraic solves stay consistent with the solver stack.
+
+    The optimizer is reset before the iteration; the initial value doubles as
+    the warm-start.
+
+    Parameters
+    ----------
+    opt : Anderson | NewtonAnderson
+        Anderson optimizer instance used to accelerate the Newton iterates
+    residual : callable
+        residual function 'F(x)' of the square system
+    x0 : float, array[float]
+        initial value / warm-start for the solution
+    jac : callable, None
+        optional analytical Jacobian of 'residual', central finite differences
+        are used as a fallback if 'None'
+    tolerance : float
+        convergence tolerance on the residual norm
+    iterations_max : int
+        maximum number of iterations
+    line_search_max : int
+        maximum number of backtracking line search steps per iteration
+
+    Returns
+    -------
+    x : array[float]
+        converged solution
+    res : float
+        residual norm at the last iteration
+    iterations : int
+        number of iterations used
+    """
+
+    #fresh optimizer state for this solve
+    opt.reset()
+
+    #working solution as a flat float array (warm-start from 'x0')
+    _x = np.atleast_1d(x0).astype(float)
+    _res, i = _inf_norm(residual, _x), 0
+
+    for i in range(iterations_max):
+
+        #converged -> early exit
+        if _res < tolerance:
+            break
+
+        #newton direction (least squares fallback if the jacobian is singular)
+        _F = np.atleast_1d(residual(_x))
+        _J = np.atleast_2d(jac(_x) if jac is not None else num_jac(residual, _x))
+        try:
+            _dx = np.linalg.solve(_J, _F)
+        except np.linalg.LinAlgError:
+            _dx, *_ = np.linalg.lstsq(_J, _F, rcond=None)
+
+        #backtracking line search keeps the step in the basin of the root
+        _a, _xn, _rn = 1.0, _x - _dx, _inf_norm(residual, _x - _dx)
+        for _ in range(line_search_max):
+            _cand = _x - _a * _dx
+            _rc = _inf_norm(residual, _cand)
+            if _rc < (1.0 - 1e-4 * _a) * _res:
+                _xn, _rn = _cand, _rc
+                break
+            _a *= 0.5
+
+        #anderson acceleration of the damped newton iterate, kept only if it
+        #does not increase the residual (safeguard against overshoot)
+        _xa = np.atleast_1d(opt.step(_x, _xn)[0]).flatten()
+        if _inf_norm(residual, _xa) <= _rn:
+            _x, _res = _xa, _inf_norm(residual, _xa)
+        else:
+            _x, _res = _xn, _rn
+
+    return _x, _res, i

--- a/src/pathsim/optim/numerical.py
+++ b/src/pathsim/optim/numerical.py
@@ -11,36 +11,37 @@
 
 import numpy as np
 
-from .. _constants import TOLERANCE
-
 
 # NUMERICAL DIFFERENTIATION ============================================================
 
-def num_jac(func, x, r=1e-3, tol=TOLERANCE):
-    """Numerically computes the jacobian of the function 'func' 
-    by central differences. 
+def num_jac(func, x, r=1e-3, tol=1e-8):
+    """Numerically computes the jacobian of the function 'func'
+    by central differences.
 
-    The stepsize 'h' is adaptively computed as a relative perturbation 
-    'r' with a small offset to avoid division by zero.
-    
+    The stepsize 'h' is adaptively computed as a relative perturbation
+    'r' with an absolute floor 'tol'. The floor keeps the perturbation
+    meaningful when components of 'x' are near zero, where a purely relative
+    step would shrink below the floating point resolution of 'func' and the
+    central difference would collapse to zero.
+
     Parameters
     ----------
     func : callable
         function to compute jacobian for
-    x : float, array[float] 
+    x : float, array[float]
         value for function at which the jacobian is evaluated
     r : float
         relative perturbation
     tol : float
-        tolerance for division by zero clipping
-    
+        absolute floor for the perturbation stepsize
+
     Returns
     -------
     jac : array[array[float]]
         2d jacobian array
     """
-    
-    #stepsize relative to value with clipping
+
+    #stepsize relative to value with an absolute floor
     H = np.clip(abs(r*x), tol, None)
 
     #catch scalar case (gradient)

--- a/tests/pathsim/optim/test_anderson.py
+++ b/tests/pathsim/optim/test_anderson.py
@@ -13,8 +13,9 @@ import unittest
 import numpy as np
 
 from pathsim.optim.anderson import (
-    Anderson, 
-    NewtonAnderson
+    Anderson,
+    NewtonAnderson,
+    solve_root
     )
 
 
@@ -151,6 +152,53 @@ class TestNewtonAnderson(unittest.TestCase):
         x0 = np.array([0.0])
         x_sol, res, iters = naa.solve(func_scalar, x0, jac=jac_scalar, iterations_max=200, tolerance=1e-10)
         self.assertAlmostEqual(x_sol[0], 0.7390851332151607, places=7)
+
+
+class TestSolveRoot(unittest.TestCase):
+    """
+    Tests for the 'solve_root' Anderson-accelerated damped Newton root solver.
+    """
+
+    def test_scalar_with_jac(self):
+        # x^2 - 2 = 0 -> sqrt(2)
+        x, res, it = solve_root(NewtonAnderson(), lambda x: x**2 - 2.0,
+                                np.array([1.0]), jac=lambda x: 2.0*x, tolerance=1e-12)
+        self.assertAlmostEqual(x[0], np.sqrt(2.0), places=10)
+        self.assertLess(res, 1e-12)
+
+    def test_scalar_numerical_jac(self):
+        x, res, it = solve_root(NewtonAnderson(), lambda x: x**2 - 2.0,
+                                np.array([1.0]), tolerance=1e-10)
+        self.assertAlmostEqual(x[0], np.sqrt(2.0), places=8)
+
+    def test_basin_preservation_cold_start(self):
+        # x^2 - 4 = 0 has roots +-2; the damped Newton must stay in the basin
+        # of the start, not jump across the root (the bug a raw fixed-point map
+        # x + F would cause)
+        func = lambda x: x**2 - 4.0
+        x_pos, *_ = solve_root(NewtonAnderson(), func, np.array([1.0]), tolerance=1e-12)
+        x_neg, *_ = solve_root(NewtonAnderson(), func, np.array([-1.0]), tolerance=1e-12)
+        self.assertAlmostEqual(x_pos[0], 2.0, places=8)
+        self.assertAlmostEqual(x_neg[0], -2.0, places=8)
+
+    def test_near_zero_start(self):
+        # F(x) = x - 3, x0 = 0 -> 3 (relies on the num_jac absolute step floor)
+        x, res, it = solve_root(NewtonAnderson(), lambda x: x - 3.0,
+                                np.array([0.0]), tolerance=1e-12)
+        self.assertAlmostEqual(x[0], 3.0, places=10)
+
+    def test_vector_nonlinear(self):
+        # circle and line: x0^2 + x1^2 = 1, x1 = x0 -> (1/sqrt2, 1/sqrt2)
+        def func(x):
+            return np.array([x[0]**2 + x[1]**2 - 1.0, x[1] - x[0]])
+        x, res, it = solve_root(NewtonAnderson(), func, np.array([0.5, 0.9]), tolerance=1e-12)
+        np.testing.assert_allclose(x, [1/np.sqrt(2), 1/np.sqrt(2)], atol=1e-8)
+
+    def test_warmstart_converges_immediately(self):
+        func = lambda x: x**2 - 2.0
+        x, *_ = solve_root(NewtonAnderson(), func, np.array([1.0]), tolerance=1e-12)
+        _, _, it = solve_root(NewtonAnderson(), func, x, tolerance=1e-12)
+        self.assertEqual(it, 0)
 
 
 # RUN TESTS LOCALLY ====================================================================


### PR DESCRIPTION
Reworks the algebraic and DAE block internals to match the patterns the rest of the solver stack uses.

- Inner algebraic solves now use the `NewtonAnderson` optimizer (consistent with the implicit engines and `SteadyState`) via a new `optim.solve_root` helper, instead of a separate root solver.
- `solve_root` is an Anderson-accelerated damped Newton: it accelerates the (line-searched) Newton iterate, not the raw fixed-point map, so cold starts stay in the root's basin (e.g. `x^2 = u` from `x0 = 1` converges to `+2`, not `-2`), with a residual safeguard against overshoot.
- The DAE blocks now wrap their reduced right hand side in a `DynamicOperator` and take the engine Jacobian from `op_dyn.jac_x`, exactly like the `ODE` block.
- `num_jac` gets an absolute step floor (1e-8) so central differences stay meaningful when state components are near zero; this hardens every finite-difference Jacobian, including the ODE block fallback.

Affects `AlgebraicConstraint` and `SemiExplicitDAE`. Full test suite green.