### PR TITLE
Cache LU factorization in NewtonAnderson Newton step

### DIFF
--- a/src/pathsim/optim/anderson.py
+++ b/src/pathsim/optim/anderson.py
@@ -11,6 +11,8 @@ import numpy as np
 
 from collections import deque
 
+from scipy.linalg import lu_factor, lu_solve
+
 from .numerical import num_jac
 
 from .._constants import (
@@ -252,6 +254,21 @@ class NewtonAnderson(Anderson):
            49(4), 1715--1735. :doi:`10.1137/10078356X`
     """
 
+    def __init__(self, m=OPT_HISTORY, restart=OPT_RESTART):
+        super().__init__(m, restart)
+
+        #cached LU factorization of the Newton matrix and the matrix it
+        #factorizes, reused across iterations / stages while it is unchanged
+        self._lu = None
+        self._A = None
+
+
+    def reset(self):
+        """Reset the anderson accelerator and the cached Newton factorization"""
+        super().reset()
+        self._lu = None
+        self._A = None
+
 
     def solve(self, func, x0, jac=None, iterations_max=100, tolerance=1e-6):
         """Solve the function 'func' with initial value 
@@ -329,8 +346,19 @@ class NewtonAnderson(Anderson):
             
             return _x - _res / (_jac - 1.0), np.linalg.norm(_res)
 
-        #vectorial values (newton raphson)
-        return _x - np.linalg.solve(_jac - np.eye(len(_res)), _res), np.linalg.norm(_res)
+        #vectorial values (newton raphson), Newton matrix 'jac - I'
+        _A = _jac - np.eye(len(_res))
+
+        #reuse the cached factorization while the Newton matrix is unchanged
+        #(constant jacobian across iterations / stages), refactor otherwise
+        if self._A is not None and _A.shape == self._A.shape \
+            and np.array_equal(_A, self._A):
+            _lu = self._lu
+        else:
+            _lu = lu_factor(_A)
+            self._A, self._lu = _A.copy(), _lu
+
+        return _x - lu_solve(_lu, _res), np.linalg.norm(_res)
 
 
     def step(self, x, g, jac=None):

--- a/tests/pathsim/optim/test_anderson.py
+++ b/tests/pathsim/optim/test_anderson.py
@@ -153,6 +153,44 @@ class TestNewtonAnderson(unittest.TestCase):
         x_sol, res, iters = naa.solve(func_scalar, x0, jac=jac_scalar, iterations_max=200, tolerance=1e-10)
         self.assertAlmostEqual(x_sol[0], 0.7390851332151607, places=7)
 
+    def test_newton_lu_matches_direct_solve(self):
+        # the cached LU path must match a direct solve of the Newton matrix (jac - I)
+        naa = NewtonAnderson()
+        x = np.array([1.0, -2.0, 0.5])
+        g = np.array([0.3, 0.1, -0.4])
+        jac = np.array([[2.0, 1.0, 0.0], [0.0, 3.0, 1.0], [1.0, 0.0, 2.0]])
+        y, _ = naa._newton(x, g, jac)
+        expected = x - np.linalg.solve(jac - np.eye(3), g - x)
+        np.testing.assert_allclose(y, expected, atol=1e-12)
+
+    def test_newton_lu_cache_reuse(self):
+        # unchanged Newton matrix -> factorization is reused, changed -> refactored
+        naa = NewtonAnderson()
+        x = np.array([1.0, 2.0])
+        g = np.array([2.0, 4.0])
+        jac = np.array([[2.0, 0.0], [0.0, 3.0]])
+
+        naa._newton(x, g, jac)
+        cached = naa._lu
+        self.assertIsNotNone(cached)
+
+        #same matrix -> same factorization object
+        naa._newton(x, g, jac)
+        self.assertIs(naa._lu, cached)
+
+        #different matrix -> new factorization
+        naa._newton(x, g, jac + np.eye(2))
+        self.assertIsNot(naa._lu, cached)
+
+    def test_newton_cache_cleared_on_reset(self):
+        naa = NewtonAnderson()
+        jac = np.array([[2.0, 0.0], [0.0, 3.0]])
+        naa._newton(np.array([1.0, 2.0]), np.array([2.0, 4.0]), jac)
+        self.assertIsNotNone(naa._A)
+        naa.reset()
+        self.assertIsNone(naa._A)
+        self.assertIsNone(naa._lu)
+
 
 class TestSolveRoot(unittest.TestCase):
     """


### PR DESCRIPTION
Caches the LU factorization of the Newton matrix `jac - I` inside `NewtonAnderson._newton` and reuses it while the matrix is unchanged across iterations or stages.

- For constant-Jacobian systems (linear / LTI blocks, or repeated stages with the same diagonal coefficient) the matrix is identical every iteration, so it is factored once and reused, replacing a fresh dense solve per iteration.
- Falls back to refactoring whenever the matrix changes, so nonlinear systems are unaffected beyond a cheap array comparison.
- The cache is cleared on `reset` (per timestep), consistent with the Anderson buffers.

Numerically identical to the previous `np.linalg.solve` path (covered by a test); cache reuse and reset are tested.