### PR TITLE
Add automatic initial timestep selection to Simulation

### DIFF
--- a/src/pathsim/blocks/_block.py
+++ b/src/pathsim/blocks/_block.py
@@ -707,10 +707,34 @@ class Block:
         return 0.0 
 
 
+    def derivative(self, t):
+        """Return the time derivative of the block state at time 't'.
+
+        This is the right hand side that the block feeds into its integration
+        engine. It is used to estimate a good initial timestep before a run.
+        The default implementation covers blocks whose dynamic path is defined
+        by an internal dynamic operator ('op_dyn'); blocks with a different
+        dynamic path reimplement this method, and stateless blocks return 'None'.
+
+        Parameters
+        ----------
+        t : float
+            evaluation time
+
+        Returns
+        -------
+        dxdt : None | float | np.ndarray
+            time derivative of the block state, or 'None' if undefined
+        """
+        if self.engine is None or self.op_dyn is None:
+            return None
+        return self.op_dyn(self.engine.state, self.inputs.to_array(), t)
+
+
     def step(self, t, dt):
-        """The 'step' method is used in transient simulations and performs an action 
-        (numeric integration timestep, recording data, etc.) based on the current 
-        inputs and the current internal state. 
+        """The 'step' method is used in transient simulations and performs an action
+        (numeric integration timestep, recording data, etc.) based on the current
+        inputs and the current internal state.
 
         It performs one timestep for the internal states. For instant time blocks,
         the 'step' method does not has to be implemented specifically. 

--- a/src/pathsim/blocks/integrator.py
+++ b/src/pathsim/blocks/integrator.py
@@ -84,6 +84,22 @@ class Integrator(Block):
         self.outputs.update_from_array(self.engine.state)
 
 
+    def derivative(self, t):
+        """time derivative of the integrator state, which is just the input
+
+        Parameters
+        ----------
+        t : float
+            evaluation time
+
+        Returns
+        -------
+        dxdt : np.ndarray
+            time derivative of the integrator state
+        """
+        return self.inputs.to_array()
+
+
     def solve(self, t, dt):
         """advance solution of implicit update equation of the solver
 
@@ -95,7 +111,7 @@ class Integrator(Block):
             integration timestep
 
         Returns
-        ------- 
+        -------
         error : float
             solver residual norm
         """

--- a/src/pathsim/simulation.py
+++ b/src/pathsim/simulation.py
@@ -1200,6 +1200,104 @@ class Simulation:
         self._set_solver(_solver)
 
 
+    # initial timestep estimation -------------------------------------------------
+
+    def estimate_initial_step(self, order=None):
+        """Estimate a good initial timestep from the system state and dynamics.
+
+        Implements the automatic initial step size selection of Hairer, Norsett
+        and Wanner: a first guess is formed from the scaled norms of the state
+        and its derivative, then refined with an estimate of the second
+        derivative obtained from an explicit Euler probe. The scaling uses the
+        absolute and relative error tolerances of the integration engine.
+
+        Note
+        ----
+        Blocks expose their state derivative through the 'Block.derivative'
+        method. Blocks that do not define it (stateless or with a custom dynamic
+        path) are skipped, and if no derivative information is available the
+        configured timestep is returned unchanged.
+
+        Parameters
+        ----------
+        order : int, None
+            order of the integration scheme, defaults to the order of the engine
+
+        Returns
+        -------
+        dt : float
+            estimated initial timestep
+
+        References
+        ----------
+        .. [1] Hairer, E., Norsett, S. P., & Wanner, G. (1993). "Solving Ordinary
+               Differential Equations I: Nonstiff Problems". Springer Series in
+               Computational Mathematics, Vol. 8, Section II.4.
+               :doi:`10.1007/978-3-540-78862-1`
+        """
+
+        #fallback timestep if no derivative information is available
+        _fallback = self.dt if self.dt is not None else SIM_TIMESTEP
+
+        #propagate inputs through the algebraic part
+        self._update(self.time)
+        t0 = self.time
+
+        #collect states and derivatives of the dynamic blocks
+        contrib, states, derivs = [], [], []
+        for b in self._blocks_dyn:
+            if not (b and b.engine):
+                continue
+            d = b.derivative(t0)
+            if d is None:
+                continue
+            s = np.atleast_1d(b.engine.state)
+            contrib.append((b, s.size))
+            states.append(s)
+            derivs.append(np.atleast_1d(d))
+
+        #no derivative information -> keep the configured timestep
+        if not derivs:
+            return _fallback
+
+        y0 = np.concatenate(states).astype(float)
+        f0 = np.concatenate(derivs).astype(float)
+
+        #weighted scaling from the engine error tolerances
+        sc = self.engine.tolerance_lte_abs + self.engine.tolerance_lte_rel * np.abs(y0)
+        d0 = np.sqrt(np.mean((y0 / sc) ** 2))
+        d1 = np.sqrt(np.mean((f0 / sc) ** 2))
+
+        #first guess for the initial step
+        h0 = 1e-6 if (d0 < 1e-5 or d1 < 1e-5) else 0.01 * d0 / d1
+
+        #estimate the second derivative from an explicit Euler probe, evaluating
+        #the dynamics at 'y0 + h0 f0' without taking an actual timestep
+        y1 = y0 + h0 * f0
+        _saved = [b.engine.state for b, _ in contrib]
+        _idx = 0
+        for b, sz in contrib:
+            b.engine.state = y1[_idx:_idx + sz]
+            _idx += sz
+        self._update(t0 + h0)
+        f1 = np.concatenate([np.atleast_1d(b.derivative(t0 + h0)) for b, _ in contrib])
+
+        #restore the original states and algebraic signals
+        for (b, _), s in zip(contrib, _saved):
+            b.engine.state = s
+        self._update(t0)
+
+        #second derivative estimate and refined step
+        d2 = np.sqrt(np.mean(((f1 - f0) / sc) ** 2)) / h0
+        p = order if order is not None else max(self.engine.n, 1)
+        if max(d1, d2) <= 1e-15:
+            h1 = max(1e-6, h0 * 1e-3)
+        else:
+            h1 = (0.01 / max(d1, d2)) ** (1.0 / (p + 1))
+
+        return float(min(100 * h0, h1))
+
+
     # timestepping helpers --------------------------------------------------------
 
     def _revert(self, t):
@@ -1628,6 +1726,11 @@ class Simulation:
 
         #simulation start and end time
         start_time, end_time = self.time, self.time + duration
+
+        #automatic initial timestep selection if no timestep is configured
+        if self.dt is None:
+            self.dt = self.estimate_initial_step()
+            self.logger.info(f"AUTO INITIAL STEP -> dt = {self.dt:.3e}")
 
         #effective timestep for duration
         _dt = self.dt

--- a/tests/pathsim/test_auto_initial_step.py
+++ b/tests/pathsim/test_auto_initial_step.py
@@ -1,0 +1,107 @@
+########################################################################################
+##
+##                                  TESTS FOR
+##                    'Simulation.estimate_initial_step' / auto dt
+##
+########################################################################################
+
+# IMPORTS ==============================================================================
+
+import unittest
+import numpy as np
+
+from pathsim import Simulation, Connection
+from pathsim.blocks import ODE, Integrator, Amplifier, Source, Scope
+
+
+# TESTS ================================================================================
+
+class TestBlockDerivative(unittest.TestCase):
+    """
+    Test the 'Block.derivative' accessor used for initial step estimation.
+    """
+
+    def test_ode_derivative(self):
+        ode = ODE(lambda x, u, t: -2.0*x, 3.0)
+        ode.set_solver(type(Simulation(log=False).engine), None)
+        d = ode.derivative(0.0)
+        np.testing.assert_allclose(np.atleast_1d(d), [-6.0])
+
+    def test_integrator_derivative(self):
+        itg = Integrator(0.0)
+        itg.set_solver(type(Simulation(log=False).engine), None)
+        itg.inputs[0] = 1.5
+        np.testing.assert_allclose(itg.derivative(0.0), [1.5])
+
+    def test_stateless_block_derivative_none(self):
+        amp = Amplifier(2.0)
+        self.assertIsNone(amp.derivative(0.0))
+
+
+class TestEstimateInitialStep(unittest.TestCase):
+    """
+    Test the 'Simulation.estimate_initial_step' Hairer-Wanner estimator.
+    """
+
+    def test_scales_with_dynamics(self):
+        #a faster system must get a smaller initial step
+        sim_slow = Simulation(blocks=[ODE(lambda x, u, t: -x, 1.0)], log=False)
+        sim_fast = Simulation(blocks=[ODE(lambda x, u, t: -100.0*x, 1.0)], log=False)
+        h_slow = sim_slow.estimate_initial_step()
+        h_fast = sim_fast.estimate_initial_step()
+        self.assertGreater(h_slow, h_fast)
+        #order of magnitude sanity: ~1/100 of the slow step
+        self.assertLess(h_fast, h_slow / 10.0)
+
+    def test_returns_positive(self):
+        sim = Simulation(blocks=[ODE(lambda x, u, t: -x, 1.0)], log=False)
+        self.assertGreater(sim.estimate_initial_step(), 0.0)
+
+    def test_no_dynamic_states_returns_fallback(self):
+        #purely algebraic system -> configured timestep is returned unchanged
+        src = Source(lambda t: t)
+        amp = Amplifier(2.0)
+        sim = Simulation(
+            blocks=[src, amp],
+            connections=[Connection(src, amp)],
+            dt=0.05, log=False
+            )
+        self.assertEqual(sim.estimate_initial_step(), 0.05)
+
+    def test_state_restored(self):
+        #the estimate must not mutate the block state
+        ode = ODE(lambda x, u, t: -x, [1.0, 2.0, 3.0])
+        sim = Simulation(blocks=[ode], log=False)
+        sim.estimate_initial_step()
+        np.testing.assert_array_equal(ode.engine.state, [1.0, 2.0, 3.0])
+        self.assertAlmostEqual(sim.time, 0.0)
+
+
+class TestAutoTimestep(unittest.TestCase):
+    """
+    Test the automatic initial timestep selection via 'dt=None'.
+    """
+
+    def test_auto_dt_resolves_and_runs(self):
+        #integrate cos(t) -> sin(t); dt=None must auto-select and run accurately
+        src = Source(lambda t: np.cos(t))
+        itg = Integrator(0.0)
+        sco = Scope()
+        sim = Simulation(
+            blocks=[src, itg, sco],
+            connections=[Connection(src, itg), Connection(itg, sco)],
+            dt=None, log=False
+            )
+        self.assertIsNone(sim.dt)
+        sim.run(1.0)
+        #dt was resolved to a concrete positive value
+        self.assertIsNotNone(sim.dt)
+        self.assertGreater(sim.dt, 0.0)
+        #result is accurate
+        self.assertAlmostEqual(float(itg.engine.state[0]), np.sin(1.0), places=3)
+
+
+# RUN TESTS LOCALLY ====================================================================
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Adds automatic initial timestep selection following Hairer-Norsett-Wanner.

- `Simulation.estimate_initial_step()` forms a first guess from the scaled norms of the state and its derivative, then refines it with a second-derivative estimate from an explicit Euler probe (a pure evaluation, no actual timestep / no events). Scaling uses the engine error tolerances.
- Blocks expose their state derivative through a new `Block.derivative(t)` accessor: the base implementation covers blocks with a dynamic operator (`ODE`, `DynamicalSystem`, `LTI`, and the DAE blocks via their reduced operator); `Integrator` overrides it; stateless blocks return `None` and are skipped.
- Passing `dt=None` to the simulation triggers the estimate at the start of the run; otherwise behaviour is unchanged.

Tests cover the derivative accessor, step scaling with the dynamics, state restoration, and an end-to-end auto-dt run.