### PR TITLE
Add periodic steady state shooting to Simulation

### DIFF
--- a/src/pathsim/simulation.py
+++ b/src/pathsim/simulation.py
@@ -31,6 +31,7 @@ from ._constants import (
     )
 
 from .optim.booster import ConnectionBooster
+from .optim.anderson import Anderson
 
 from .utils.graph import Graph
 from .utils.analysis import Timer
@@ -228,6 +229,9 @@ class Simulation:
 
         #flag for setting the simulation active
         self._active = True
+
+        #flag to suppress data sampling (used during shooting iterations)
+        self._sampling_enabled = True
 
         #convergence trackers for the three solver loops
         self._loop_tracker = ConvergenceTracker()
@@ -1298,6 +1302,184 @@ class Simulation:
         return float(min(100 * h0, h1))
 
 
+    # periodic steady state -------------------------------------------------------
+
+    def _pss_get_state(self):
+        """Collect the internal states of all dynamic blocks.
+
+        Returns
+        -------
+        states : list[array[float]]
+            list of the engine state arrays of the dynamic blocks
+        """
+        return [np.atleast_1d(b.engine.state).copy()
+                for b in self._blocks_dyn if b and b.engine]
+
+
+    def _pss_set_state(self, states):
+        """Distribute a list of state arrays back onto the dynamic blocks.
+
+        Parameters
+        ----------
+        states : list[array[float]]
+            list of state arrays in the order of the dynamic blocks
+        """
+        i = 0
+        for b in self._blocks_dyn:
+            if b and b.engine:
+                b.engine.state = states[i]
+                i += 1
+
+
+    def _pss_integrate(self, t_start, period, dt):
+        """Integrate the system over exactly one period with fixed timesteps,
+        leaving the engines at the end-of-period state.
+
+        Parameters
+        ----------
+        t_start : float
+            start time of the period
+        period : float
+            length of the period
+        dt : float
+            fixed integration timestep
+        """
+        self.time = t_start
+        t_end = t_start + period
+        while self.time < t_end - 1e-12:
+            h = min(dt, t_end - self.time)
+            self.timestep(dt=h, adaptive=False)
+
+
+    def pss(self, period, transient=0.0, iterations_max=50, tolerance=1e-8,
+            dt=None, reset=False):
+        """Find the periodic steady state (limit cycle) of the system by
+        shooting.
+
+        For a system with period `T` the periodic steady state is the initial
+        condition :math:`x_0` that is invariant under the period map
+        :math:`P` which integrates the system over one period,
+
+        .. math::
+
+            P(x_0) = x_0, \\qquad P(x_0) = x(t_0 + T;\\, x_0)
+
+
+        The fixed point is found by an Anderson accelerated shooting iteration
+        on :math:`x_0`, where each shot integrates one period with fixed
+        timesteps. Data sampling is suppressed during the shooting iterations,
+        so recording blocks stay clean; after convergence the engines are left
+        at the limit-cycle initial state and the simulation time at the cycle
+        start, ready for a final recording run over one period.
+
+        Note
+        ----
+        This is a matrix-free shooting method (no monodromy matrix) and is
+        best suited to single-step integrators. An optional `transient` run can
+        be used to approach the limit cycle before shooting. Event handling is
+        not considered during the shooting iterations.
+
+        Parameters
+        ----------
+        period : float
+            period of the steady state
+        transient : float
+            duration of an optional transient run to approach the limit cycle
+        iterations_max : int
+            maximum number of shooting iterations
+        tolerance : float
+            convergence tolerance on the shooting residual
+        dt : float, None
+            fixed timestep for the period integration, defaults to `self.dt`
+        reset : bool
+            reset the simulation before solving (default False)
+
+        Returns
+        -------
+        success : bool
+            whether the shooting iteration converged
+        iterations : int
+            number of shooting iterations used
+        residual : float
+            shooting residual at the last iteration
+
+        References
+        ----------
+        .. [1] Aprille, T. J., & Trick, T. N. (1972). "Steady-state analysis of
+               nonlinear circuits with periodic inputs". Proceedings of the
+               IEEE, 60(1), 108--114. :doi:`10.1109/PROC.1972.8563`
+        """
+
+        #reset the simulation before solving
+        if reset:
+            self.reset()
+
+        #fixed timestep for the period integration
+        _dt = self.dt if dt is None else dt
+
+        #approach the limit cycle with an optional transient run
+        if transient > 0.0:
+            self.run(transient, reset=False, adaptive=False)
+
+        #nothing to do without dynamic states
+        if not self._pss_get_state():
+            self.logger.info("PSS -> no dynamic states, nothing to solve")
+            return True, 0, 0.0
+
+        #cycle start time and shooting accelerator
+        t0 = self.time
+        acc = Anderson()
+
+        self.logger.info(
+            f"PSS -> STARTING (period: {period}, transient: {transient})"
+            )
+
+        #suppress data sampling during the shooting iterations
+        _sampling = self._sampling_enabled
+        self._sampling_enabled = False
+
+        success, residual, it = False, 0.0, 0
+        with Timer(verbose=False) as T:
+            try:
+                for it in range(iterations_max):
+
+                    #current cycle-start state as a flat vector
+                    _states = self._pss_get_state()
+                    _split = np.cumsum([s.size for s in _states])[:-1]
+                    x0 = np.concatenate(_states)
+
+                    #integrate one period -> period map P(x0)
+                    self._pss_integrate(t0, period, _dt)
+                    x1 = np.concatenate(self._pss_get_state())
+
+                    #accelerated fixed-point step on P(x0) = x0
+                    x_new, residual = acc.step(x0, x1)
+
+                    #rewind to the cycle start with the updated initial state
+                    self.time = t0
+                    self._pss_set_state(np.split(x_new, _split))
+
+                    if residual < tolerance:
+                        success = True
+                        break
+            finally:
+                self._sampling_enabled = _sampling
+
+        #log the outcome
+        if success:
+            self.logger.info(
+                "PSS -> FINISHED (success: {}, iterations: {}, residual: {:.2e}, runtime: {})".format(
+                    success, it + 1, residual, T)
+                )
+        else:
+            self.logger.error(
+                "PSS -> FAILED (iterations: {}, residual: {:.2e}, runtime: {})".format(
+                    it + 1, residual, T)
+                )
+
+        return success, it + 1, residual
+
+
     # timestepping helpers --------------------------------------------------------
 
     def _revert(self, t):
@@ -1332,6 +1514,9 @@ class Simulation:
         t : float
             time where to sample
         """
+        #sampling can be suppressed during shooting iterations
+        if not self._sampling_enabled:
+            return
         for block in self.blocks:
             if block: block.sample(t, dt)
 

--- a/tests/pathsim/test_simulation_pss.py
+++ b/tests/pathsim/test_simulation_pss.py
@@ -1,0 +1,106 @@
+########################################################################################
+##
+##                                  TESTS FOR
+##                       'Simulation.pss' (periodic steady state)
+##
+########################################################################################
+
+# IMPORTS ==============================================================================
+
+import unittest
+import numpy as np
+
+from pathsim import Simulation, Connection
+from pathsim.blocks import ODE, Constant, Amplifier, Scope
+from pathsim.solvers.esdirk43 import ESDIRK43
+
+
+# TESTS ================================================================================
+
+class TestPeriodicSteadyState(unittest.TestCase):
+    """
+    Test the 'Simulation.pss' periodic steady state shooting method.
+    """
+
+    def test_forced_linear_scalar(self):
+        #x' = -x + sin(t), periodic solution x_p = (sin t - cos t)/2, x_p(0) = -0.5
+        ode = ODE(lambda x, u, t: -x + np.sin(t), 0.0)
+        sim = Simulation(blocks=[ode], dt=0.01, Solver=ESDIRK43, log=False)
+
+        success, iters, res = sim.pss(period=2*np.pi, dt=0.01)
+
+        self.assertTrue(success)
+        self.assertLess(res, 1e-8)
+        self.assertAlmostEqual(float(ode.engine.state[0]), -0.5, places=6)
+
+
+    def test_time_reset_to_cycle_start(self):
+        ode = ODE(lambda x, u, t: -x + np.sin(t), 0.0)
+        sim = Simulation(blocks=[ode], dt=0.01, Solver=ESDIRK43, log=False)
+        sim.pss(period=2*np.pi, dt=0.01)
+        #the simulation time is left at the cycle start
+        self.assertAlmostEqual(sim.time, 0.0, places=12)
+
+
+    def test_self_consistent_vector(self):
+        #damped driven oscillator, x = [pos, vel]
+        def func(x, u, t):
+            return np.array([x[1], -x[0] - 0.3*x[1] + np.cos(t)])
+
+        ode = ODE(func, [0.0, 0.0])
+        sim = Simulation(blocks=[ode], dt=0.005, Solver=ESDIRK43, log=False)
+
+        success, iters, res = sim.pss(period=2*np.pi, dt=0.005)
+        self.assertTrue(success)
+
+        #the found state must reproduce itself after exactly one period
+        x0 = ode.engine.state.copy()
+        sim._pss_integrate(sim.time, 2*np.pi, 0.005)
+        np.testing.assert_allclose(ode.engine.state, x0, atol=1e-4)
+
+
+    def test_sampling_suppressed_during_shooting(self):
+        #scopes must not record during the shooting iterations
+        ode = ODE(lambda x, u, t: -x + np.sin(t), 0.0)
+        sco = Scope()
+        sim = Simulation(
+            blocks=[ode, sco],
+            connections=[Connection(ode[0], sco[0])],
+            dt=0.01, Solver=ESDIRK43, log=False
+            )
+        sim.pss(period=2*np.pi, dt=0.01)
+        self.assertEqual(len(sco.recording_time), 0)
+        #sampling is re-enabled afterwards
+        self.assertTrue(sim._sampling_enabled)
+
+
+    def test_no_dynamic_states(self):
+        #a purely algebraic system has no periodic steady state to solve
+        src = Constant(1.0)
+        amp = Amplifier(2.0)
+        sim = Simulation(
+            blocks=[src, amp],
+            connections=[Connection(src, amp)],
+            log=False
+            )
+        success, iters, res = sim.pss(period=1.0)
+        self.assertTrue(success)
+        self.assertEqual(iters, 0)
+
+
+    def test_transient_then_shoot(self):
+        #a transient run before shooting must still converge to the same cycle
+        ode = ODE(lambda x, u, t: -x + np.sin(t), 5.0)
+        sim = Simulation(blocks=[ode], dt=0.01, Solver=ESDIRK43, log=False)
+        success, iters, res = sim.pss(period=2*np.pi, transient=10*np.pi, dt=0.01)
+        self.assertTrue(success)
+        #periodic solution x_p(t) = (sin t - cos t)/2 at the actual cycle start
+        t0 = sim.time
+        expected = 0.5 * (np.sin(t0) - np.cos(t0))
+        self.assertAlmostEqual(float(ode.engine.state[0]), expected, places=5)
+
+
+# RUN TESTS LOCALLY ====================================================================
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Adds `Simulation.pss(period, ...)` to find the periodic steady state (limit cycle) of a system by shooting.

- Anderson-accelerated shooting on the initial state: each shot integrates exactly one period with fixed timesteps and the period map fixed point is the limit-cycle initial condition.
- Data sampling is suppressed during the shooting iterations (new `_sampling_enabled` flag guarding `_sample`), so recording blocks stay clean; after convergence the engines are left at the cycle start, ready for a final recording run.
- Optional `transient` run to approach the cycle before shooting.

Tests cover a forced linear system (analytic), self-consistency of the period map, sampling suppression, the no-dynamic-states case and a transient warmup.