### PR TITLE
Add max_nodes passthrough to BVP1D block

### DIFF
--- a/src/pathsim/blocks/bvp.py
+++ b/src/pathsim/blocks/bvp.py
@@ -116,6 +116,10 @@ class BVP1D(Block):
         initial guess for the free parameters, `None` if there are none
     tol : float
         solver tolerance passed to :func:`scipy.integrate.solve_bvp`
+    max_nodes : int
+        maximum number of mesh nodes allowed during refinement, passed to
+        :func:`scipy.integrate.solve_bvp`. A solve that would exceed this cap
+        fails and the previous output and warm-start are retained.
 
     Attributes
     ----------
@@ -135,7 +139,8 @@ class BVP1D(Block):
         x_eval=None,
         y0=None,
         p0=None,
-        tol=1e-6
+        tol=1e-6,
+        max_nodes=1000
         ):
 
         super().__init__()
@@ -157,8 +162,9 @@ class BVP1D(Block):
         self.x_eval = (np.linspace(a, b, n_nodes) if x_eval is None
                        else np.asarray(x_eval, dtype=float))
 
-        #solver tolerance
+        #solver tolerance and mesh node cap
         self.tol = tol
+        self.max_nodes = int(max_nodes)
 
         #initial mesh and solution guess (used as warm-start)
         self._x0 = np.linspace(a, b, n_nodes)
@@ -254,11 +260,13 @@ class BVP1D(Block):
         if self._has_p:
             _fun = lambda x, y, p: self.fun(x, y, p, u)
             _bc = lambda ya, yb, p: self.bc(ya, yb, p, u)
-            sol = solve_bvp(_fun, _bc, self._x, self._y, p=self._p, tol=self.tol)
+            sol = solve_bvp(_fun, _bc, self._x, self._y, p=self._p,
+                            tol=self.tol, max_nodes=self.max_nodes)
         else:
             _fun = lambda x, y: self.fun(x, y, None, u)
             _bc = lambda ya, yb: self.bc(ya, yb, None, u)
-            sol = solve_bvp(_fun, _bc, self._x, self._y, tol=self.tol)
+            sol = solve_bvp(_fun, _bc, self._x, self._y,
+                            tol=self.tol, max_nodes=self.max_nodes)
 
         self.success = bool(sol.success)
 

--- a/tests/pathsim/blocks/test_bvp.py
+++ b/tests/pathsim/blocks/test_bvp.py
@@ -106,8 +106,47 @@ class TestBVP1D(unittest.TestCase):
     def test_info(self):
         info = BVP1D.info()
         self.assertEqual(info["type"], "BVP1D")
-        for p in ("fun", "bc", "n", "domain", "n_nodes", "x_eval", "y0", "p0", "tol"):
+        for p in ("fun", "bc", "n", "domain", "n_nodes", "x_eval", "y0", "p0",
+                  "tol", "max_nodes"):
             self.assertIn(p, info["parameters"])
+
+
+    def test_max_nodes_passthrough(self):
+        #max_nodes is stored as int and forwarded to solve_bvp
+        fun = lambda x, y, p, u: np.vstack([y[1], -y[0]])
+        bc = lambda ya, yb, p, u: np.array([ya[0], yb[0] - 1.0])
+        bvp = BVP1D(fun, bc, n=2, domain=(0.0, np.pi/2), max_nodes=5000)
+        self.assertEqual(bvp.max_nodes, 5000)
+
+        import pathsim.blocks.bvp as bvpmod
+        captured = {}
+        orig = bvpmod.solve_bvp
+        def _capture(*a, **k):
+            captured["max_nodes"] = k.get("max_nodes")
+            return orig(*a, **k)
+        bvpmod.solve_bvp = _capture
+        try:
+            bvp.update(0.0)
+        finally:
+            bvpmod.solve_bvp = orig
+        self.assertEqual(captured["max_nodes"], 5000)
+
+
+    def test_max_nodes_too_small_fails(self):
+        #a cap below the nodes required for convergence makes the solve fail,
+        #raising max_nodes recovers it
+        fun = lambda x, y, p, u: np.vstack([y[1], -y[0]])
+        bc = lambda ya, yb, p, u: np.array([ya[0], yb[0] - 1.0])
+
+        tight = BVP1D(fun, bc, n=2, domain=(0.0, np.pi/2), n_nodes=3,
+                      tol=1e-10, max_nodes=4)
+        tight.update(0.0)
+        self.assertFalse(tight.success)
+
+        loose = BVP1D(fun, bc, n=2, domain=(0.0, np.pi/2), n_nodes=3,
+                      tol=1e-10, max_nodes=10000)
+        loose.update(0.0)
+        self.assertTrue(loose.success)
 
 
     def test_simulation(self):


### PR DESCRIPTION
Adds an optional `max_nodes` parameter to the `BVP1D` block, forwarded to `scipy.integrate.solve_bvp`. Defaults to scipy's default of 1000, so existing behaviour is unchanged. Needed for problems whose adaptive mesh refines beyond 1000 nodes (e.g. the pathsim-chem GLC bubble-column model, which refines to ~2750 nodes). Includes tests for the passthrough and the convergence cap.