### PR TITLE
Fix skrf VectorFitting import for scikit-rf >= 1.10

### DIFF
--- a/src/pathsim/blocks/rf.py
+++ b/src/pathsim/blocks/rf.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, TypeVar
 
 try:
     import skrf as rf
+    from skrf.vectorFitting import VectorFitting as _VectorFitting
 
     HAS_SKRF = True
 except ImportError:
@@ -85,12 +86,12 @@ class RFNetwork(StateSpace):
 
         # Select the vector fitting function from scikit-rf
         vf_fun_name = "auto_fit" if auto_fit else "vector_fit"
-        vf_fun = getattr(rf.VectorFitting, vf_fun_name)
+        vf_fun = getattr(_VectorFitting, vf_fun_name)
         # Filter kwargs for the selected vf function
         vf_fun_keys = signature(vf_fun).parameters
         vf_kwargs = {k: v for k, v in kwargs.items() if k in vf_fun_keys}
         # Apply vector fitting
-        vf = rf.VectorFitting(ntwk)
+        vf = _VectorFitting(ntwk)
         getattr(vf, vf_fun_name)(**vf_kwargs)
         A, B, C, D, _ = vf._get_ABCDE()
         # keep a copy of the network and VF
@@ -113,6 +114,6 @@ class RFNetwork(StateSpace):
         s : :py:class:`~numpy.ndarray`
             Complex-valued S-matrices (fxNxN) calculated at frequencies `freqs`.
         """
-        return rf.VectorFitting._get_s_from_ABCDE(
+        return _VectorFitting._get_s_from_ABCDE(
             freqs, self.A, self.B, self.C, self.D, 0
         )


### PR DESCRIPTION
scikit-rf 1.10 removed the top-level `skrf.VectorFitting` attribute (the name now resolves to the `vectorFitting` module), which breaks the RF blocks and all `tests/pathsim/blocks/rf` tests on a fresh environment: `AttributeError: module 'skrf' has no attribute 'VectorFitting'`.

This switches to the version-agnostic module-path import `from skrf.vectorFitting import VectorFitting`, which works on both old and new scikit-rf releases. All 6 RF tests pass locally against scikit-rf 1.10.0.

Note: this breakage is independent of #233 — CI on any branch fails since the scikit-rf release (master's last green run predates it). Merging this first will let #233 re-run clean.