### PR TITLE
Fix remaining skrf.VectorFitting usage in test_rf.py

### DIFF
--- a/tests/pathsim/blocks/rf/test_rf.py
+++ b/tests/pathsim/blocks/rf/test_rf.py
@@ -69,7 +69,7 @@ class TestOnePort(unittest.TestCase):
         "Test space-state ABCD parameters."
         # ABCD(E) arrays from scikit-rf
         ntwk = rf.data.ring_slot_meas
-        vf = rf.VectorFitting(ntwk)
+        vf = rf.vectorFitting.VectorFitting(ntwk)
         vf.auto_fit()
         A, B, C, D, E = vf._get_ABCDE()
 


### PR DESCRIPTION
One usage of the removed top-level `skrf.VectorFitting` attribute survived #234 — in the test file itself (`test_rf.py:72`, `TestOnePort::test_ABCD`). Switched to the module-path form like line 51 already uses. All 6 RF tests pass locally against scikit-rf 1.10.0. This should turn master CI fully green.