### PR TITLE
Fix FMU co-simulation test platform selection and step-size/tolerance typing

### DIFF
--- a/src/pathsim/utils/fmuwrapper.py
+++ b/src/pathsim/utils/fmuwrapper.py
@@ -411,7 +411,8 @@ class FMUWrapper:
         """Get default step size from FMU's default experiment, if defined."""
         de = self.model_description.defaultExperiment
         if de is not None:
-            return getattr(de, 'stepSize', None)
+            step_size = getattr(de, 'stepSize', None)
+            return float(step_size) if step_size is not None else None
         return None
 
     @property
@@ -419,7 +420,8 @@ class FMUWrapper:
         """Get default tolerance from FMU's default experiment, if defined."""
         de = self.model_description.defaultExperiment
         if de is not None:
-            return getattr(de, 'tolerance', None)
+            tolerance = getattr(de, 'tolerance', None)
+            return float(tolerance) if tolerance is not None else None
         return None
 
     @property

--- a/tests/pathsim/utils/test_fmuwrapper.py
+++ b/tests/pathsim/utils/test_fmuwrapper.py
@@ -10,12 +10,19 @@
 import unittest
 import numpy as np
 import os
+import platform
 
 from pathlib import Path
 
 
 # Path to test FMU files
 TEST_DATA_DIR = Path(__file__).parent.parent.parent.parent / "docs" / "source" / "examples" / "data"
+
+# Co-simulation test FMU per host platform
+_PLATFORM_FMU_NAMES = {
+    "Windows": "CoupledClutches_CS_win64.fmu",
+    "Linux": "CoupledClutches_CS_linux64.fmu",
+}
 
 
 # Helper to check if FMPy is available
@@ -52,13 +59,14 @@ class TestFMUWrapperCoSimulation(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        """Check if test FMU exists"""
-        cls.fmu_path = TEST_DATA_DIR / "CoupledClutches_CS_win64.fmu"
+        """Check if test FMU exists for the host platform"""
+        fmu_name = _PLATFORM_FMU_NAMES.get(platform.system())
+        if fmu_name is None:
+            raise unittest.SkipTest(f"No test FMU available for platform '{platform.system()}'")
+
+        cls.fmu_path = TEST_DATA_DIR / fmu_name
         if not cls.fmu_path.exists():
-            # Try linux version
-            cls.fmu_path = TEST_DATA_DIR / "CoupledClutches_CS_linux64.fmu"
-        if not cls.fmu_path.exists():
-            raise unittest.SkipTest(f"Test FMU not found in {TEST_DATA_DIR}")
+            raise unittest.SkipTest(f"Test FMU not found: {cls.fmu_path}")
 
     def setUp(self):
         from pathsim.utils.fmuwrapper import FMUWrapper


### PR DESCRIPTION
## Summary
- `TestFMUWrapperCoSimulation.setUpClass` always picked the win64 FMU fixture because both platform binaries are committed to the repo, so the existence check never fell through to the linux64 fixture on non-Windows hosts. This made all 7 co-simulation tests fail locally on Linux/macOS (only masked in CI, which skips this class entirely).
- While fixing that, discovered `FMUWrapper.default_step_size` / `default_tolerance` returned raw strings from FMPy's `DefaultExperiment` instead of floats. `blocks/fmu.py` relies on `default_step_size` as a fallback for `dt` when none is passed explicitly, so an unconverted string could reach arithmetic downstream.

## Changes
1. Select the co-simulation test FMU based on `platform.system()` instead of file existence, skipping cleanly if no fixture exists for the host platform.
2. Cast `default_step_size` / `default_tolerance` to `float` before returning.

## Test plan
- [x] `pytest tests/pathsim/utils/test_fmuwrapper.py` — 27 passed, 1 skipped (previously 7 failed)
- [x] Full suite: `pytest` — 1054 passed, 13 skipped, 0 failed (previously 7 failed)